### PR TITLE
Add referenced object

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/test/SBOLTestSuite" vcs="Git" />
   </component>
 </project>

--- a/sbol3/__init__.py
+++ b/sbol3/__init__.py
@@ -4,8 +4,10 @@ from .object import SBOLObject
 from .property import Property, SingletonProperty, ListProperty
 from .text_property import TextSingletonProperty, TextProperty
 from .uri_property import URIProperty
+from .refobj_property import ReferencedObject
 from .identified import Identified
 from .toplevel import TopLevel
 from .component import Component
 from .model import Model
+from .sequence import Sequence
 from .document import Document

--- a/sbol3/__init__.py
+++ b/sbol3/__init__.py
@@ -4,9 +4,9 @@ from .object import SBOLObject
 from .property import Property, SingletonProperty, ListProperty
 from .text_property import TextSingletonProperty, TextProperty
 from .uri_property import URIProperty
-from .refobj_property import ReferencedObject
 from .identified import Identified
 from .toplevel import TopLevel
+from .refobj_property import ReferencedObject
 from .component import Component
 from .model import Model
 from .sequence import Sequence

--- a/sbol3/component.py
+++ b/sbol3/component.py
@@ -10,8 +10,8 @@ class Component(TopLevel):
         super().__init__()
         self.roles = URIProperty(self, SBOL_ROLE, 0, math.inf)
         self.types: Union[List, Property] = URIProperty(self, SBOL_TYPE, 1, math.inf)
-        self.sequences = URIProperty(self, SBOL_SEQUENCES, 0, math.inf)
-        self.models = URIProperty(self, SBOL_MODELS, 0, math.inf)
+        self.sequences = ReferencedObject(self, SBOL_SEQUENCES, 0, math.inf)
+        self.models = ReferencedObject(self, SBOL_MODELS, 0, math.inf)
 
     def _validate_types(self) -> None:
         # A Component is REQUIRED to have one or more type properties (Section 6.4)

--- a/sbol3/constants.py
+++ b/sbol3/constants.py
@@ -26,6 +26,8 @@ PROV_NS = 'https://www.w3.org/TR/prov-o/'
 # ----------
 SBOL_DESCRIPTION = SBOL3_NS + 'description'
 SBOL_DISPLAY_ID = SBOL3_NS + 'displayId'
+SBOL_ELEMENTS = SBOL3_NS + 'elements'
+SBOL_ENCODING = SBOL3_NS + 'encoding'
 SBOL_FRAMEWORK = SBOL3_NS + 'framework'
 SBOL_HAS_ATTACHMENT = SBOL3_NS + 'hasAttachment'
 SBOL_LANGUAGE = SBOL3_NS + 'language'

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -77,6 +77,16 @@ class Document:
         self.namespaces = {prefix: uri for prefix, uri in graph.namespaces()
                            if prefix}
 
+    def add(self, obj: TopLevel) -> None:
+        """Add objects to the document.
+        """
+        if isinstance(obj, TopLevel):
+            self.objects.append(obj)
+            obj.document = self
+        else:
+            message = f'Expected TopLevel instance, {type(obj).__name__} found'
+            raise TypeError(message)
+
     def _find_in_objects(self, search_string: str) -> Optional[Identified]:
         # TODO: implement recursive search
         for obj in self.objects:

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -9,8 +9,9 @@ from . import *
 class Document:
 
     uri_type_map: Dict[str, Callable] = {
+        'http://sbols.org/v3#Component': Component,
         'http://sbols.org/v3#Model': Model,
-        'http://sbols.org/v3#Component': Component
+        'http://sbols.org/v3#Sequence': Sequence,
     }
 
     def __init__(self):
@@ -33,6 +34,7 @@ class Document:
                 builder = SBOLObject
             obj = builder()
             obj.identity = str_s
+            obj.document = self
             result[str_s] = obj
         return result
 
@@ -65,18 +67,13 @@ class Document:
         graph.parse(data=contents, format=format)
         objects = self._parse_objects(graph)
         self._parse_attributes(objects, graph)
-        # Now what?
-        # We've got the objects, now we need to store them within the document.
-        # Also extract the namespaces from the graph.
-        for prefix, uri in graph.namespaces():
-            if not prefix:
-                continue
-            print(f'{prefix}: {uri}')
-        # TODO: validate all objects
+        # Validate all the objects
         for obj in objects.values():
             obj.validate()
+        # Store the TopLevel objects in the Document
         self.objects = [obj for uri, obj in objects.items()
                         if isinstance(obj, TopLevel)]
+        # Store the namespaces in the Document for later use
         self.namespaces = {prefix: uri for prefix, uri in graph.namespaces()
                            if prefix}
 

--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -10,6 +10,7 @@ class SBOLObject:
         # Could it be an attribute that gets composed on the fly? Keep it simple for
         # now, and change to a property in the future if needed.
         self.identity = None
+        self.document = None
 
     def __setattr__(self, name, value):
         try:

--- a/sbol3/refobj_property.py
+++ b/sbol3/refobj_property.py
@@ -54,6 +54,10 @@ class ReferencedObjectSingleton(ReferencedObjectMixin, SingletonProperty):
         if initial_value:
             self.set(initial_value)
 
+    def set(self, value: Any) -> None:
+        super().set(value)
+        self.maybe_add_to_document(value)
+
 
 class ReferencedObjectList(ReferencedObjectMixin, ListProperty):
 

--- a/sbol3/refobj_property.py
+++ b/sbol3/refobj_property.py
@@ -1,0 +1,72 @@
+from typing import Union, Any, List, Optional
+
+import rdflib
+
+from . import *
+
+
+class ReferencedURI(str):
+
+    def __eq__(self, other):
+        return super().__eq__(other)
+
+    def lookup(self):
+        if hasattr(self, 'parent'):
+            print(f'Property owner = {self.parent}')
+            return self.parent.document.find(str(self))
+        else:
+            # TODO: Should the lack of a parent raise an error?
+            return None
+
+
+class ReferencedObjectMixin:
+
+    def to_user(self, value: Any) -> str:
+        result = ReferencedURI(str(value))
+        if hasattr(self, 'property_owner'):
+            parent = self.property_owner
+            result.parent = parent
+        return result
+
+    @staticmethod
+    def from_user(value: Any) -> rdflib.URIRef:
+        if not isinstance(value, str):
+            raise TypeError(f'Expecting string, got {type(value)}')
+        return rdflib.URIRef(value)
+
+
+class ReferencedObjectSingleton(ReferencedObjectMixin, SingletonProperty):
+
+    def __init__(self, property_owner: Any, property_uri: str,
+                 lower_bound: int, upper_bound: int,
+                 validation_rules: Optional[List] = None,
+                 initial_value: Optional[str] = None):
+        super().__init__(property_owner, property_uri,
+                         lower_bound, upper_bound, validation_rules)
+        if initial_value:
+            self.set(initial_value)
+
+
+class ReferencedObjectList(ReferencedObjectMixin, ListProperty):
+
+    def __init__(self, property_owner: Any, property_uri: str,
+                 lower_bound: int, upper_bound: int,
+                 validation_rules: Optional[List] = None,
+                 initial_value: Optional[str] = None):
+        super().__init__(property_owner, property_uri,
+                         lower_bound, upper_bound, validation_rules)
+        if initial_value:
+            self.set(initial_value)
+
+
+def ReferencedObject(property_owner: Any, property_uri: str,
+                     lower_bound: int, upper_bound: Union[int, float],
+                     validation_rules: Optional[List] = None,
+                     initial_value: Optional[Union[str, List[str]]] = None) -> Property:
+    if upper_bound == 1:
+        return ReferencedObjectSingleton(property_owner, property_uri,
+                                         lower_bound, upper_bound,
+                                         validation_rules, initial_value)
+    return ReferencedObjectList(property_owner, property_uri,
+                                lower_bound, upper_bound,
+                                validation_rules, initial_value)

--- a/sbol3/sequence.py
+++ b/sbol3/sequence.py
@@ -1,0 +1,12 @@
+from . import *
+
+
+class Sequence(TopLevel):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.elements = TextProperty(self, SBOL_ELEMENTS, 0, 1)
+        self.encoding = URIProperty(self, SBOL_ENCODING, 1, 1)
+
+    def validate(self) -> None:
+        super().validate()

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import unittest
 
@@ -8,6 +9,10 @@ SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 
 
 class TestDocument(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        logging.basicConfig(level=logging.INFO)
 
     def test_read_ntriples(self):
         # Initial test of Document.read

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -48,3 +48,15 @@ class TestDocument(unittest.TestCase):
         test_path = os.path.join(SBOL3_LOCATION, 'toggle_switch', 'toggle_switch.turtle.sbol')
         doc = sbol3.Document()
         doc.read(test_path, format='turtle')
+
+    def test_add(self):
+        doc = sbol3.Document()
+        obj1 = sbol3.SBOLObject()
+        with self.assertRaises(TypeError):
+            doc.add(obj1)
+        seq_uri = 'https://github.com/synbiodex/pysbol3/seq1'
+        seq = sbol3.Sequence()
+        seq.identity = seq_uri
+        doc.add(seq)
+        seq2 = doc.find(seq_uri)
+        self.assertEqual(seq.identity, seq2.identity)

--- a/test/test_referenced_object.py
+++ b/test/test_referenced_object.py
@@ -40,9 +40,9 @@ class TestReferencedObject(unittest.TestCase):
         self.assertIsNotNone(seq)
         self.assertEqual(sequence, seq)
 
-    @unittest.expectedFailure
-    def test_instance_assignment(self):
-        # Test assignment to a ReferencedObject attribute with a URI string
+    def test_instance_append(self):
+        # Test assignment to a ReferencedObject attribute with an
+        # instance using append
         seq_uri = 'https://github.com/synbiodex/pysbol3/seq1'
         doc = sbol3.Document()
         component = sbol3.Component()
@@ -50,6 +50,22 @@ class TestReferencedObject(unittest.TestCase):
         sequence.identity = seq_uri
         doc.add(component)
         component.sequences.append(sequence)
+        seq2_uri = component.sequences[0]
+        self.assertEqual(sequence.identity, seq2_uri)
+        seq = seq2_uri.lookup()
+        self.assertIsNotNone(seq)
+        self.assertEqual(sequence, seq)
+
+    def test_instance_assignment(self):
+        # Test assignment to a ReferencedObject attribute with an
+        # instance using assignment
+        seq_uri = 'https://github.com/synbiodex/pysbol3/seq1'
+        doc = sbol3.Document()
+        component = sbol3.Component()
+        sequence = sbol3.Sequence()
+        sequence.identity = seq_uri
+        doc.add(component)
+        component.sequences = [sequence]
         seq2_uri = component.sequences[0]
         self.assertEqual(sequence.identity, seq2_uri)
         seq = seq2_uri.lookup()

--- a/test/test_referenced_object.py
+++ b/test/test_referenced_object.py
@@ -1,0 +1,44 @@
+import os
+import unittest
+
+import sbol3
+
+MODULE_LOCATION = os.path.dirname(os.path.abspath(__file__))
+SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
+
+
+class TestReferencedObject(unittest.TestCase):
+
+    def test_lookup(self):
+        test_path = os.path.join(SBOL3_LOCATION, 'entity', 'model', 'model.turtle.sbol')
+        test_format = 'turtle'
+
+        doc = sbol3.Document()
+        doc.read(test_path, test_format)
+        component = doc.find('toggle_switch')
+        self.assertIsNotNone(component)
+        model_uri = component.models[0]
+        self.assertTrue(isinstance(model_uri, str))
+        self.assertTrue(hasattr(model_uri, 'lookup'))
+        self.assertEqual('https://sbolstandard.org/examples/model1', model_uri)
+        model = model_uri.lookup()
+        self.assertIsNotNone(model)
+
+    @unittest.expectedFailure
+    def test_uri_assignment(self):
+        # Test assignment to a ReferencedObject attribute with a URI string
+        doc = sbol3.Document()
+        component = sbol3.Component()
+        sequence = sbol3.Sequence()
+        doc.add(component)
+        doc.add(sequence)
+        component.sequences.append(sequence.identity)
+        seq_uri = component.sequences[0]
+        self.assertEqual(sequence.identity, seq_uri)
+        seq = seq_uri.lookup()
+        self.assertIsNotNone(seq)
+        self.assertEqual(sequence, seq)
+
+    @unittest.expectedFailure
+    def test_instance_assignment(self):
+        self.fail('Not implemented yet')

--- a/test/test_referenced_object.py
+++ b/test/test_referenced_object.py
@@ -24,21 +24,34 @@ class TestReferencedObject(unittest.TestCase):
         model = model_uri.lookup()
         self.assertIsNotNone(model)
 
-    @unittest.expectedFailure
     def test_uri_assignment(self):
         # Test assignment to a ReferencedObject attribute with a URI string
+        seq_uri = 'https://github.com/synbiodex/pysbol3/seq1'
         doc = sbol3.Document()
         component = sbol3.Component()
         sequence = sbol3.Sequence()
+        sequence.identity = seq_uri
         doc.add(component)
         doc.add(sequence)
         component.sequences.append(sequence.identity)
-        seq_uri = component.sequences[0]
-        self.assertEqual(sequence.identity, seq_uri)
-        seq = seq_uri.lookup()
+        seq2_uri = component.sequences[0]
+        self.assertEqual(sequence.identity, seq2_uri)
+        seq = seq2_uri.lookup()
         self.assertIsNotNone(seq)
         self.assertEqual(sequence, seq)
 
     @unittest.expectedFailure
     def test_instance_assignment(self):
-        self.fail('Not implemented yet')
+        # Test assignment to a ReferencedObject attribute with a URI string
+        seq_uri = 'https://github.com/synbiodex/pysbol3/seq1'
+        doc = sbol3.Document()
+        component = sbol3.Component()
+        sequence = sbol3.Sequence()
+        sequence.identity = seq_uri
+        doc.add(component)
+        component.sequences.append(sequence)
+        seq2_uri = component.sequences[0]
+        self.assertEqual(sequence.identity, seq2_uri)
+        seq = seq2_uri.lookup()
+        self.assertIsNotNone(seq)
+        self.assertEqual(sequence, seq)

--- a/test/test_referenced_object.py
+++ b/test/test_referenced_object.py
@@ -7,6 +7,15 @@ MODULE_LOCATION = os.path.dirname(os.path.abspath(__file__))
 SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 
 
+class SingleRefObj(sbol3.TopLevel):
+
+    SEQUENCE_URI = 'https://github.com/synbiodex/sbol3#sequence'
+
+    def __init__(self):
+        super().__init__()
+        self.sequence = sbol3.ReferencedObject(self, SingleRefObj.SEQUENCE_URI, 0, 1)
+
+
 class TestReferencedObject(unittest.TestCase):
 
     def test_lookup(self):
@@ -67,6 +76,22 @@ class TestReferencedObject(unittest.TestCase):
         doc.add(component)
         component.sequences = [sequence]
         seq2_uri = component.sequences[0]
+        self.assertEqual(sequence.identity, seq2_uri)
+        seq = seq2_uri.lookup()
+        self.assertIsNotNone(seq)
+        self.assertEqual(sequence, seq)
+
+    def test_singleton_assignment(self):
+        # Test assignment to a ReferencedObject attribute with an
+        # instance using assignment
+        seq_uri = 'https://github.com/synbiodex/pysbol3/seq1'
+        doc = sbol3.Document()
+        test_parent = SingleRefObj()
+        sequence = sbol3.Sequence()
+        sequence.identity = seq_uri
+        doc.add(test_parent)
+        test_parent.sequence = sequence
+        seq2_uri = test_parent.sequence
         self.assertEqual(sequence.identity, seq2_uri)
         seq = seq2_uri.lookup()
         self.assertIsNotNone(seq)


### PR DESCRIPTION
Include a `lookup()` method on the returned URI so that the object or objects can be easily looked up in the containing document.