### PR TITLE
Support list-like behavior of list properties

### DIFF
--- a/test/test_component.py
+++ b/test/test_component.py
@@ -25,3 +25,7 @@ class TestComponent(unittest.TestCase):
         c.roles[1:] = [sbol3.SO_RBS]
         self.assertEqual([sbol3.SO_PROMOTER, sbol3.SO_RBS], c.roles)
         self.assertEqual([sbol3.SO_RBS], c.roles[1:])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -60,3 +60,7 @@ class TestDocument(unittest.TestCase):
         doc.add(seq)
         seq2 = doc.find(seq_uri)
         self.assertEqual(seq.identity, seq2.identity)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_identified.py
+++ b/test/test_identified.py
@@ -21,3 +21,7 @@ class TestIdentified(unittest.TestCase):
         # Under the covers
         self.assertIsInstance(c.properties[sbol3.SBOL_DISPLAY_ID][0],
                               rdflib.Literal)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_referenced_object.py
+++ b/test/test_referenced_object.py
@@ -96,3 +96,7 @@ class TestReferencedObject(unittest.TestCase):
         seq = seq2_uri.lookup()
         self.assertIsNotNone(seq)
         self.assertEqual(sequence, seq)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Properties whose upper bound is greater than 1 should behave like lists. Most of this was done in earlier merges. This PR finishes the job.

Fixes #8 
