### PR TITLE
Update identity for child objects

### DIFF
--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -40,6 +40,11 @@ class SBOLObject:
         pass
 
     @staticmethod
+    def _is_url(name: str) -> bool:
+        parsed = urlparse(name)
+        return bool(parsed.scheme and parsed.netloc and parsed.path)
+
+    @staticmethod
     def _make_identity(name: str) -> str:
         """Make an identity from the given name.
 
@@ -51,8 +56,7 @@ class SBOLObject:
 
         We do not support UUIDs, which are legal SBOL identifiers.
         """
-        parsed = urlparse(name)
-        name_is_url = bool(parsed.scheme and parsed.netloc and parsed.path)
+        name_is_url = SBOLObject._is_url(name)
         if name_is_url:
             return name.strip(posixpath.sep)
         try:
@@ -72,6 +76,9 @@ class SBOLObject:
         self._validate_identity()
 
     @property
-    def identity(self):
+    def identity(self) -> str:
         # identity is a read-only property
         return self._identity
+
+    def identity_is_url(self) -> bool:
+        return self._is_url(self.identity)

--- a/sbol3/refobj_property.py
+++ b/sbol3/refobj_property.py
@@ -70,14 +70,8 @@ class ReferencedObjectList(ReferencedObjectMixin, ListProperty):
         if initial_value:
             self.set(initial_value)
 
-    def insert(self, index: int, value: Any) -> None:
-        super().insert(index, value)
-        self.maybe_add_to_document(value)
-
-    def set(self, value: Any) -> None:
-        super().set(value)
-        for item in value:
-            self.maybe_add_to_document(item)
+    def item_added(self, item: Any) -> None:
+        self.maybe_add_to_document(item)
 
 
 def ReferencedObject(property_owner: Any, property_uri: str,

--- a/test/test_ownedobject.py
+++ b/test/test_ownedobject.py
@@ -1,0 +1,56 @@
+import posixpath
+import unittest
+
+import sbol3
+
+
+class TestOwnedObject(unittest.TestCase):
+
+    def test_identity_append(self):
+        comp = sbol3.Component('c1')
+        con1_id = 'con1'
+        con1 = sbol3.Constraint(con1_id)
+        expected = posixpath.join(sbol3.get_homespace(), con1_id)
+        expected2 = posixpath.join(comp.identity, con1_id)
+        self.assertNotEqual(expected, expected2)
+        self.assertEqual(expected, con1.identity)
+        # Append should cause the constraint's identity to change
+        comp.constraints.append(con1)
+        self.assertEqual(expected2, con1.identity)
+
+    def test_identity_set(self):
+        comp = sbol3.Component('c1')
+        con1_id = 'con1'
+        con1 = sbol3.Constraint(con1_id)
+        expected = posixpath.join(sbol3.get_homespace(), con1_id)
+        expected2 = posixpath.join(comp.identity, con1_id)
+        self.assertNotEqual(expected, expected2)
+        self.assertEqual(expected, con1.identity)
+        # Append should cause the constraint's identity to change
+        comp.constraints = [con1]
+        self.assertEqual(expected2, con1.identity)
+
+    def test_identity_conflict(self):
+        # Test that the same display id will cause a validation
+        # error when an item with the same display id is appended
+        comp = sbol3.Component('c1')
+        con1_id = 'con1'
+        comp.constraints.append(sbol3.Constraint(con1_id))
+        with self.assertRaises(sbol3.ValidationError):
+            comp.constraints.append(sbol3.Constraint(con1_id))
+
+    def test_identity_conflict2(self):
+        # Test that the same display id will cause a validation
+        # error when an item with the same display id is appended
+        comp = sbol3.Component('c1')
+        con1_id = 'con1'
+        constraints = [sbol3.Constraint(con1_id), sbol3.Constraint(con1_id)]
+        with self.assertRaises(sbol3.ValidationError):
+            comp.constraints = constraints
+
+    # TODO: Write tests for adding via a slice
+    #       comp.constraints[0:1] = sbol3.Constraint('foo')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
SBOL3 requires that child objects have an identity that is the parent's identity plus the child's display id. This update makes that happen, and verifies that there are no duplicate ids.