### PR TITLE
Check for duplicate identities when adding to document

### DIFF
--- a/.idea/pySBOL3.iml
+++ b/.idea/pySBOL3.iml
@@ -2,6 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/sbol3.egg-info" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -156,12 +156,16 @@ class Document:
     def add(self, obj: TopLevel) -> None:
         """Add objects to the document.
         """
-        if isinstance(obj, TopLevel):
-            self.objects.append(obj)
-            obj.document = self
-        else:
+        if not isinstance(obj, TopLevel):
             message = f'Expected TopLevel instance, {type(obj).__name__} found'
             raise TypeError(message)
+        found_obj = self.find(obj.identity)
+        if found_obj is not None:
+            message = f'An entity with identity "{obj.identity}"'
+            message += ' already exists in document'
+            raise ValueError(message)
+        self.objects.append(obj)
+        obj.document = self
 
     def _find_in_objects(self, search_string: str) -> Optional[Identified]:
         # TODO: implement recursive search

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -69,6 +69,16 @@ class TestDocument(unittest.TestCase):
         seq2 = doc.find(seq.identity)
         self.assertEqual(seq.identity, seq2.identity)
 
+    def test_add_multiple(self):
+        # Ensure that duplicate identities cannot be added to the document.
+        # See https://github.com/SynBioDex/pySBOL3/issues/39
+        document = sbol3.Document()
+        namespace1 = sbol3.Namespace(name=sbol3.SBOL3_NS)
+        document.add(namespace1)
+        namespace2 = sbol3.Namespace(name=sbol3.SBOL3_NS)
+        with self.assertRaises(ValueError):
+            document.add(namespace2)
+
     def test_write(self):
         doc = sbol3.Document()
         doc.add(sbol3.Component('c1', sbol3.SBO_DNA))


### PR DESCRIPTION
Raise a ValueError if the object being added has an identity that is
already present in the document.

Closes #39 
Closes #40 
