### PR TITLE
Finish off Constraint

### DIFF
--- a/sbol3/constraint.py
+++ b/sbol3/constraint.py
@@ -1,16 +1,39 @@
+from typing import Optional, Union
+
 from . import *
 
 
 class Constraint(Identified):
 
-    def __init__(self, name: str, *, type_uri: str = SBOL_CONSTRAINT) -> None:
+    def __init__(self, restriction: str, subject: Union[Identified, str],
+                 object: Union[Identified, str], *, name: Optional[str] = None,
+                 type_uri: str = SBOL_CONSTRAINT) -> None:
         super().__init__(name, type_uri)
-        self.restriction = URIProperty(self, SBOL_RESTRICTION, 1, 1)
-        self.subject = ReferencedObject(self, SBOL_SUBJECT, 1, 1)
-        self.object = ReferencedObject(self, SBOL_OBJECT, 1, 1)
+        self.restriction = URIProperty(self, SBOL_RESTRICTION, 1, 1,
+                                       initial_value=restriction)
+        self.subject = ReferencedObject(self, SBOL_SUBJECT, 1, 1,
+                                        initial_value=subject)
+        self.object = ReferencedObject(self, SBOL_OBJECT, 1, 1,
+                                       initial_value=object)
+        self.validate()
 
     def validate(self) -> None:
         super().validate()
+        if not self.restriction:
+            raise ValidationError('Constraint must have a restriction')
+        if not self.subject:
+            raise ValidationError('Constraint must have a subject')
+        if not self.object:
+            raise ValidationError('Constraint must have an object')
 
 
-Document.register_builder(SBOL_CONSTRAINT, Constraint)
+def build_constraint(name: str, type_uri: str = SBOL_CONSTRAINT) -> SBOLObject:
+    missing = PYSBOL3_MISSING
+    obj = Constraint(missing, missing, missing, name=name, type_uri=type_uri)
+    obj._properties[SBOL_RESTRICTION] = []
+    obj._properties[SBOL_SUBJECT] = []
+    obj._properties[SBOL_OBJECT] = []
+    return obj
+
+
+Document.register_builder(SBOL_CONSTRAINT, build_constraint)

--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -38,6 +38,8 @@ class Identified(SBOLObject):
 
     @staticmethod
     def _extract_display_id(identity: str) -> Union[None, str]:
+        if not identity:
+            return None
         parsed = urlparse(identity)
         if not (parsed.scheme and parsed.netloc and parsed.path):
             # if the identity is not a URL, we cannot extract a display id
@@ -48,7 +50,7 @@ class Identified(SBOLObject):
             return display_id
         else:
             msg = f'"{display_id}" is not a valid displayId.'
-            msg += '  A displayId MUST be composed of only alphanumeric'
+            msg += ' A displayId MUST be composed of only alphanumeric'
             msg += ' or underscore characters and MUST NOT begin with a digit.'
             raise ValueError(msg)
 

--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -59,6 +59,8 @@ class SBOLObject:
 
         We do not support UUIDs, which are legal SBOL identifiers.
         """
+        if name is None:
+            return None
         name_is_url = SBOLObject._is_url(name)
         if name_is_url:
             return name.strip(posixpath.sep)
@@ -73,7 +75,7 @@ class SBOLObject:
         if base_uri.endswith('#'):
             return base_uri + name
         else:
-            return posixpath.join(base_uri, name)
+            return posixpath.join(base_uri, name.lstrip(posixpath.sep))
 
     def validate(self) -> None:
         self._validate_identity()

--- a/sbol3/ownedobject.py
+++ b/sbol3/ownedobject.py
@@ -43,18 +43,35 @@ class OwnedObjectListProperty(OwnedObjectPropertyMixin, ListProperty):
         if initial_value:
             self.set(initial_value)
 
+    def counter_value(self, type_name: str):
+        result = 0
+        for sibling in self._storage()[self.property_uri]:
+            if sibling.display_id and sibling.display_id.startswith(type_name):
+                counter_string = sibling.display_id[len(type_name):]
+                counter_int = int(counter_string)
+                if counter_int > result:
+                    result = counter_int
+        return result + 1
+
     def item_added(self, item: Any) -> None:
         if not self.property_owner.identity_is_url():
             return
-        if not item.display_id:
-            raise ValueError(f'Item {item} does not have a display_id')
-        new_url = posixpath.join(self.property_owner.identity, item.display_id)
+        # if not item.display_id:
+        #     raise ValueError(f'Item {item} does not have a display_id')
+        if not item.type_uri.startswith(SBOL3_NS):
+            # what do we do here?
+            pass
+        type_name = item.type_uri[len(SBOL3_NS):]
+        counter_value = self.counter_value(type_name)
+        new_display_id = f'{type_name}{counter_value}'
+        new_url = posixpath.join(self.property_owner.identity, new_display_id)
         for sibling in self._storage()[self.property_uri]:
             if sibling == item:
                 continue
             if sibling.identity == new_url:
                 raise ValidationError(f'Duplicate URI: {new_url}')
         item._identity = new_url
+        item._display_id = new_display_id
 
 
 def OwnedObject(property_owner: Any, property_uri: str,

--- a/test/test_ownedobject.py
+++ b/test/test_ownedobject.py
@@ -9,9 +9,16 @@ class TestOwnedObject(unittest.TestCase):
     def test_identity_append(self):
         comp = sbol3.Component('c1', sbol3.SBO_DNA)
         con1_id = 'con1'
-        con1 = sbol3.Constraint(con1_id)
+        con1 = sbol3.Constraint(sbol3.SBOL_REPLACES,
+                                'http://example.com/fake1',
+                                'http://example.com/fake2',
+                                name=con1_id)
         expected = posixpath.join(sbol3.get_homespace(), con1_id)
-        expected2 = posixpath.join(comp.identity, con1_id)
+        # The constraint's identity and display_id will be overwritten as
+        # part of the append operation. SBOL Compliant URIs (identities)
+        # use the class of the object and a counter to generate the
+        # display_id.
+        expected2 = posixpath.join(comp.identity, 'Constraint1')
         self.assertNotEqual(expected, expected2)
         self.assertEqual(expected, con1.identity)
         # Append should cause the constraint's identity to change
@@ -19,34 +26,52 @@ class TestOwnedObject(unittest.TestCase):
         self.assertEqual(expected2, con1.identity)
 
     def test_identity_set(self):
+        # This test uses assignment instead of appending
         comp = sbol3.Component('c1', sbol3.SBO_DNA)
         con1_id = 'con1'
-        con1 = sbol3.Constraint(con1_id)
+        con1 = sbol3.Constraint(sbol3.SBOL_REPLACES,
+                                'http://example.com/fake1',
+                                'http://example.com/fake2',
+                                name=con1_id)
         expected = posixpath.join(sbol3.get_homespace(), con1_id)
-        expected2 = posixpath.join(comp.identity, con1_id)
+        expected2 = posixpath.join(comp.identity, 'Constraint1')
         self.assertNotEqual(expected, expected2)
         self.assertEqual(expected, con1.identity)
-        # Append should cause the constraint's identity to change
+        # Setting to list should cause the constraint's identity to change
         comp.constraints = [con1]
         self.assertEqual(expected2, con1.identity)
 
-    def test_identity_conflict(self):
-        # Test that the same display id will cause a validation
-        # error when an item with the same display id is appended
+    def test_add_multiple_children(self):
+        # Test that the the display_id and identity are overwritten
+        # properly when adding multiple child entities.
         comp = sbol3.Component('c1', sbol3.SBO_DNA)
-        con1_id = 'con1'
-        comp.constraints.append(sbol3.Constraint(con1_id))
-        with self.assertRaises(sbol3.ValidationError):
-            comp.constraints.append(sbol3.Constraint(con1_id))
+        comp.constraints.append(sbol3.Constraint(sbol3.SBOL_REPLACES,
+                                                 'http://example.com/fake1',
+                                                 'http://example.com/fake2'))
+        expected1 = posixpath.join(comp.identity, 'Constraint1')
+        self.assertEqual(expected1, comp.constraints[0].identity)
+        comp.constraints.append(sbol3.Constraint(sbol3.SBOL_REPLACES,
+                                                 'http://example.com/fake1',
+                                                 'http://example.com/fake2'))
+        expected2 = posixpath.join(comp.identity, 'Constraint2')
+        self.assertEqual(expected2, comp.constraints[1].identity)
 
     def test_identity_conflict2(self):
         # Test that the same display id will cause a validation
         # error when an item with the same display id is appended
         comp = sbol3.Component('c1', sbol3.SBO_DNA)
         con1_id = 'con1'
-        constraints = [sbol3.Constraint(con1_id), sbol3.Constraint(con1_id)]
-        with self.assertRaises(sbol3.ValidationError):
-            comp.constraints = constraints
+        constraints = [sbol3.Constraint(sbol3.SBOL_REPLACES,
+                                        'http://example.com/fake1',
+                                        'http://example.com/fake2'),
+                       sbol3.Constraint(sbol3.SBOL_REPLACES,
+                                        'http://example.com/fake1',
+                                        'http://example.com/fake2')]
+        comp.constraints = constraints
+        expected1 = posixpath.join(comp.identity, 'Constraint1')
+        self.assertEqual(expected1, comp.constraints[0].identity)
+        expected2 = posixpath.join(comp.identity, 'Constraint2')
+        self.assertEqual(expected2, comp.constraints[1].identity)
 
     # TODO: Write tests for adding via a slice
     #       comp.constraints[0:1] = sbol3.Constraint('foo')


### PR DESCRIPTION
Make the required properties be required arguments to the constructor.
Make the optional properties, like identity/display_id, be optional in
the constructor since this is an Identified. Change some of the Identified
infrastructure to allow the absence of identity/display_id.