### PR TITLE
Make identity/display_id optional for all non-TopLevel classes

### DIFF
--- a/sbol3/compref.py
+++ b/sbol3/compref.py
@@ -7,9 +7,10 @@ from .feature import Feature
 
 class ComponentReference(Feature):
 
-    def __init__(self, name: str, in_child_of: Union[SBOLObject, str],
-                 feature: Union[SBOLObject, str],
-                 *, type_uri: str = SBOL_COMPONENT_REFERENCE) -> None:
+    def __init__(self, in_child_of: Union[SubComponent, str],
+                 feature: Union[Feature, str],
+                 *, name: str = None,
+                 type_uri: str = SBOL_COMPONENT_REFERENCE) -> None:
         super().__init__(name, type_uri)
         self.in_child_of = ReferencedObject(self, SBOL_IN_CHILD_OF, 1, 1,
                                             initial_value=in_child_of)
@@ -31,7 +32,7 @@ class ComponentReference(Feature):
 def build_component_reference(name: str, *,
                               type_uri: str = SBOL_COMPONENT_REFERENCE) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = ComponentReference(name, missing, missing, type_uri=type_uri)
+    obj = ComponentReference(missing, missing, name=name, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[SBOL_FEATURES] = []
     obj._properties[SBOL_IN_CHILD_OF] = []

--- a/sbol3/extdef.py
+++ b/sbol3/extdef.py
@@ -13,8 +13,9 @@ class ExternallyDefined(Feature):
     can be referenced.
     """
 
-    def __init__(self, name: str, types: List[str], definition: str,
-                 *, type_uri: str = SBOL_EXTERNALLY_DEFINED):
+    def __init__(self, types: List[str], definition: str,
+                 *, name: str = None,
+                 type_uri: str = SBOL_EXTERNALLY_DEFINED):
         super().__init__(name, type_uri)
         self.types: uri_list = URIProperty(self, SBOL_TYPE, 1, math.inf,
                                            initial_value=types)
@@ -33,7 +34,7 @@ class ExternallyDefined(Feature):
 def build_externally_defined(name: str,
                              *, type_uri: str = SBOL_EXTERNALLY_DEFINED) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = ExternallyDefined(name, [missing], missing, type_uri=type_uri)
+    obj = ExternallyDefined([missing], missing, name=name, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[SBOL_TYPE] = []
     obj._properties[SBOL_DEFINITION] = []

--- a/sbol3/interaction.py
+++ b/sbol3/interaction.py
@@ -6,8 +6,9 @@ from . import *
 
 class Interaction(Identified):
 
-    def __init__(self, name: str, interaction_type: List[str],
-                 *, type_uri: str = SBOL_INTERACTION) -> None:
+    def __init__(self, interaction_type: List[str],
+                 *, name: str = None,
+                 type_uri: str = SBOL_INTERACTION) -> None:
         super().__init__(name, type_uri)
         self.types = URIProperty(self, SBOL_TYPE, 1, math.inf,
                                  initial_value=interaction_type)
@@ -19,7 +20,7 @@ class Interaction(Identified):
 
 def build_interaction(name: str, *, type_uri: str = SBOL_INTERACTION) -> SBOLObject:
     interaction_type = PYSBOL3_MISSING
-    obj = Interaction(name, [interaction_type], type_uri=type_uri)
+    obj = Interaction([interaction_type], name=name, type_uri=type_uri)
     # Remove the dummy type
     obj._properties[SBOL_TYPE] = []
     return obj

--- a/sbol3/interface.py
+++ b/sbol3/interface.py
@@ -5,7 +5,8 @@ from . import *
 
 class Interface(Identified):
 
-    def __init__(self, name: str, *, type_uri: str = SBOL_INTERFACE) -> None:
+    def __init__(self, *, name: str = None,
+                 type_uri: str = SBOL_INTERFACE) -> None:
         super().__init__(name, type_uri)
         self.input = ReferencedObject(self, SBOL_INPUT, 0, math.inf)
         self.output = ReferencedObject(self, SBOL_OUTPUT, 0, math.inf)
@@ -16,4 +17,8 @@ class Interface(Identified):
         super().validate()
 
 
-Document.register_builder(SBOL_INTERFACE, Interface)
+def build_interface(name: str, *, type_uri: str = SBOL_INTERFACE) -> SBOLObject:
+    return Interface(name=name, type_uri=type_uri)
+
+
+Document.register_builder(SBOL_INTERFACE, build_interface)

--- a/sbol3/localsub.py
+++ b/sbol3/localsub.py
@@ -8,8 +8,9 @@ from .typing import *
 
 class LocalSubComponent(Feature):
 
-    def __init__(self, name: str, types: List[str],
-                 *, type_uri: str = SBOL_LOCAL_SUBCOMPONENT) -> None:
+    def __init__(self, types: List[str],
+                 *, name: str = None,
+                 type_uri: str = SBOL_LOCAL_SUBCOMPONENT) -> None:
         super().__init__(name, type_uri)
         self.types: uri_list = URIProperty(self, SBOL_TYPE, 1, math.inf,
                                            initial_value=types)
@@ -25,7 +26,7 @@ class LocalSubComponent(Feature):
 def build_local_subcomponent(name: str,
                              *, type_uri: str = SBOL_LOCAL_SUBCOMPONENT) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = LocalSubComponent(name, [missing], type_uri=type_uri)
+    obj = LocalSubComponent([missing], name=name, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[SBOL_TYPE] = []
     return obj

--- a/sbol3/location.py
+++ b/sbol3/location.py
@@ -16,16 +16,8 @@ class Location(Identified, abc.ABC):
 
 class Range(Location):
 
-    @staticmethod
-    def _builder(identity_uri: str, type_uri: str = SBOL_RANGE):
-        """Used by Document to construct a SubComponent when reading an SBOL file.
-        """
-        start = 1
-        end = 1
-        return Range(identity_uri, start, end, type_uri=type_uri)
-
-    def __init__(self, name: str, start: int, end: int,
-                 *, type_uri: str = SBOL_RANGE, ) -> None:
+    def __init__(self, start: int, end: int,
+                 *, name: str = None, type_uri: str = SBOL_RANGE) -> None:
         super().__init__(name, type_uri)
         self.start: int_property = IntProperty(self, SBOL_START, 1, 1,
                                                initial_value=start)
@@ -43,20 +35,25 @@ class Range(Location):
             raise ValidationError('End must be >= start')
 
 
-Document.register_builder(SBOL_RANGE, Range._builder)
+def build_range(name: str, type_uri: str = SBOL_RANGE):
+    """Used by Document to construct a Range when reading an SBOL file.
+    """
+    start = 1
+    end = 1
+    obj = Range(start, end, name=name, type_uri=type_uri)
+    # Remove the dummy values
+    obj._properties[SBOL_START] = []
+    obj._properties[SBOL_END] = []
+    return obj
+
+
+Document.register_builder(SBOL_RANGE, build_range)
 
 
 class Cut(Location):
 
-    @staticmethod
-    def _builder(identity_uri: str, type_uri: str = SBOL_CUT):
-        """Used by Document to construct a SubComponent when reading an SBOL file.
-        """
-        at = 0
-        return Cut(identity_uri, at, type_uri=type_uri)
-
-    def __init__(self, name: str, at: int,
-                 *, type_uri: str = SBOL_CUT) -> None:
+    def __init__(self, at: int,
+                 *, name: str = None, type_uri: str = SBOL_CUT) -> None:
         super().__init__(name, type_uri)
         self.at: int_property = IntProperty(self, SBOL_START, 1, 1,
                                             initial_value=at)
@@ -68,15 +65,32 @@ class Cut(Location):
             raise ValidationError('At must be >= 0')
 
 
-Document.register_builder(SBOL_CUT, Cut._builder)
+def build_cut(name: str, type_uri: str = SBOL_CUT):
+    """Used by Document to construct a Cut when reading an SBOL file.
+    """
+    at = 0
+    obj = Cut(at, name=name, type_uri=type_uri)
+    # Remove the dummy values
+    obj._properties[SBOL_START] = []
+    return obj
+
+
+Document.register_builder(SBOL_CUT, build_cut)
 
 
 class EntireSequence(Location):
 
-    def __init__(self, name: str, *,
+    def __init__(self, *, name: str = None,
                  type_uri: str = SBOL_ENTIRE_SEQUENCE) -> None:
         super().__init__(name, type_uri)
         self.validate()
+
+
+def build_entire_sequence(name: str, type_uri: str = SBOL_ENTIRE_SEQUENCE):
+    """Used by Document to construct an EntireSequence when reading an SBOL file.
+    """
+    obj = EntireSequence(name=name, type_uri=type_uri)
+    return obj
 
 
 Document.register_builder(SBOL_ENTIRE_SEQUENCE, EntireSequence)

--- a/sbol3/om_unit.py
+++ b/sbol3/om_unit.py
@@ -29,8 +29,9 @@ class Unit(TopLevel, abc.ABC):
 
 class Measure(Identified):
 
-    def __init__(self, name: str, value: float, unit: str,
-                 *, type_uri: str = OM_MEASURE) -> None:
+    def __init__(self, value: float, unit: str,
+                 *, name: str = None,
+                 type_uri: str = OM_MEASURE) -> None:
         super().__init__(name, type_uri)
         self.value = FloatProperty(self, OM_HAS_NUMERICAL_VALUE, 1, 1,
                                    initial_value=value)
@@ -42,7 +43,7 @@ class Measure(Identified):
 
 def build_measure(name: str, *, type_uri: str = OM_MEASURE) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = Measure(name, 1.0, missing, type_uri=type_uri)
+    obj = Measure(1.0, missing, name=name, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[OM_HAS_NUMERICAL_VALUE] = []
     obj._properties[OM_HAS_UNIT] = []

--- a/sbol3/ownedobject.py
+++ b/sbol3/ownedobject.py
@@ -77,7 +77,8 @@ class OwnedObjectListProperty(OwnedObjectPropertyMixin, ListProperty):
 def OwnedObject(property_owner: Any, property_uri: str,
                 lower_bound: int, upper_bound: Union[int, float],
                 validation_rules: Optional[List] = None,
-                initial_value: Optional[Union[str, List[str]]] = None) -> Property:
+                initial_value: Optional[Union['Identified', List['Identified']]] = None)\
+        -> Property:
     if upper_bound == 1:
         return OwnedObjectSingletonProperty(property_owner, property_uri,
                                             lower_bound, upper_bound,

--- a/sbol3/participation.py
+++ b/sbol3/participation.py
@@ -1,17 +1,18 @@
 import math
-from typing import List, Union
 
 from . import *
+from .typing import *
 
 
 class Participation(Identified):
 
-    def __init__(self, name: str, role: List[str],
+    def __init__(self, role: List[str],
                  participant: Union[SBOLObject, str],
-                 *, type_uri: str = SBOL_PARTCIPATION) -> None:
+                 *, name: str = None,
+                 type_uri: str = SBOL_PARTCIPATION) -> None:
         super().__init__(name, type_uri)
-        self.roles = URIProperty(self, SBOL_ROLE, 1, math.inf,
-                                 initial_value=role)
+        self.roles: uri_list = URIProperty(self, SBOL_ROLE, 1, math.inf,
+                                           initial_value=role)
         self.participant = ReferencedObject(self, SBOL_PARTICIPANT, 1, 1,
                                             initial_value=participant)
         self.validate()
@@ -24,9 +25,9 @@ class Participation(Identified):
             raise ValidationError('Participation must have a participant')
 
 
-def build_participation(name: str, *, type_uri: str = SBOL_INTERACTION) -> SBOLObject:
+def build_participation(name: str, *, type_uri: str = SBOL_PARTCIPATION) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = Participation(name, [missing], missing, type_uri=type_uri)
+    obj = Participation([missing], missing, name=name, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[SBOL_ROLE] = []
     obj._properties[SBOL_PARTICIPANT] = []

--- a/sbol3/provenance.py
+++ b/sbol3/provenance.py
@@ -6,7 +6,8 @@ from . import *
 
 class Usage(Identified):
 
-    def __init__(self, name: str, entity: str, *, type_uri: str = PROV_USAGE) -> None:
+    def __init__(self, entity: str, *, name: str = None,
+                 type_uri: str = PROV_USAGE) -> None:
         super().__init__(name, type_uri)
         self.entity = URIProperty(self, PROV_ENTITY, 1, 1,
                                   initial_value=entity)
@@ -16,7 +17,7 @@ class Usage(Identified):
 
 def build_usage(name: str, *, type_uri: str = PROV_USAGE) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = Usage(name, missing, type_uri=type_uri)
+    obj = Usage(missing, name=name, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[PROV_ENTITY] = []
     return obj
@@ -47,8 +48,9 @@ Document.register_builder(PROV_PLAN, Plan)
 
 class Association(Identified):
 
-    def __init__(self, name: str, agent: Union[str, Identified],
-                 *, type_uri: str = PROV_ASSOCIATION) -> None:
+    def __init__(self, agent: Union[str, Identified],
+                 *, name: str = None,
+                 type_uri: str = PROV_ASSOCIATION) -> None:
         super().__init__(name, type_uri)
         self.roles = URIProperty(self, PROV_ROLES, 0, math.inf)
         self.plan = ReferencedObject(self, PROV_PLANS, 0, 1)
@@ -59,7 +61,7 @@ class Association(Identified):
 
 def build_association(name: str, *, type_uri: str = PROV_USAGE) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = Association(name, missing, type_uri=type_uri)
+    obj = Association(missing, name=name, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[PROV_AGENTS] = []
     return obj

--- a/sbol3/seqfeat.py
+++ b/sbol3/seqfeat.py
@@ -9,11 +9,13 @@ from .typing import *
 
 class SequenceFeature(Feature):
 
-    def __init__(self, name: str, locations: List[Location],
-                 *, type_uri: str = SBOL_SEQUENCE_FEATURE) -> None:
+    def __init__(self, locations: List[Location],
+                 *, name: str = None,
+                 type_uri: str = SBOL_SEQUENCE_FEATURE) -> None:
         super().__init__(name, type_uri)
-        self.locations = OwnedObject(self, SBOL_LOCATION, 1, math.inf,
-                                     initial_value=locations)
+        self.locations: oo_list = OwnedObject(self, SBOL_LOCATION,
+                                              1, math.inf,
+                                              initial_value=locations)
         self.validate()
 
     def validate(self):
@@ -24,8 +26,7 @@ class SequenceFeature(Feature):
 
 def build_sequence_feature(name: str,
                            *, type_uri: str = SBOL_SEQUENCE_FEATURE) -> SBOLObject:
-    missing = PYSBOL3_MISSING
-    obj = LocalSubComponent(name, [missing], type_uri=type_uri)
+    obj = SequenceFeature([EntireSequence()], name=name, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[SBOL_LOCATION] = []
     return obj

--- a/sbol3/subcomponent.py
+++ b/sbol3/subcomponent.py
@@ -8,29 +8,30 @@ from .feature import Feature
 
 class SubComponent(Feature):
 
-    @staticmethod
-    def _builder(identity_uri: str, type_uri: str = SBOL_SUBCOMPONENT):
-        """Used by Document to construct a SubComponent when reading an SBOL file.
-        """
-        return SubComponent(identity_uri, PYSBOL3_MISSING, type_uri=type_uri)
-
-    def __init__(self, name: str, instance_of: Union[SBOLObject, str],
-                 *, type_uri: str = SBOL_SUBCOMPONENT) -> None:
+    def __init__(self, instance_of: Union[Identified, str],
+                 *, name: str = None, type_uri: str = SBOL_SUBCOMPONENT) -> None:
         super().__init__(name, type_uri)
         self.role_integration = URIProperty(self, SBOL_ROLE, 0, 1)
         self.instance_of = ReferencedObject(self, SBOL_INSTANCE_OF, 1, 1,
                                             initial_value=instance_of)
         self.source_locations = OwnedObject(self, SBOL_SOURCE_LOCATION, 0, math.inf)
         self.locations = OwnedObject(self, SBOL_LOCATION, 0, math.inf)
+        self.validate()
 
     def validate(self) -> None:
         super().validate()
         # If there is an orientation, it must be in the valid set
-        if self.orientation is not None:
-            valid_orientations = [SBOL_INLINE, SBOL_REVERSE_COMPLEMENT]
-            if self.orientation not in valid_orientations:
-                message = f'{self.orientation} is not a valid orientation'
-                raise ValidationError(message)
+        if not self.instance_of:
+            raise ValidationError('SubComponent must have an instance_of')
 
 
-Document.register_builder(SBOL_SUBCOMPONENT, SubComponent._builder)
+def build_subcomponent(name: str, type_uri: str = SBOL_SUBCOMPONENT) -> Identified:
+    """Used by Document to construct a SubComponent when reading an SBOL file.
+    """
+    missing = PYSBOL3_MISSING
+    obj = SubComponent(missing, name=name, type_uri=type_uri)
+    obj._properties[SBOL_INSTANCE_OF] = []
+    return obj
+
+
+Document.register_builder(SBOL_SUBCOMPONENT, build_subcomponent)

--- a/sbol3/typing.py
+++ b/sbol3/typing.py
@@ -5,3 +5,5 @@ from .property_base import Property
 # URIProperty typing
 uri_list = Union[List[str], Property]
 uri_singleton = Union[str, Property]
+# Owned object property
+oo_list = Union[List['Identified'], Property]

--- a/sbol3/varcomp.py
+++ b/sbol3/varcomp.py
@@ -5,9 +5,10 @@ from . import *
 
 class VariableComponent(Identified):
 
-    def __init__(self, name: str, *,
+    def __init__(self, *,
                  cardinality: str = None,
                  variable: str = None,
+                 name: str = None,
                  type_uri: str = SBOL_VARIABLE_COMPONENT) -> None:
         super().__init__(name, type_uri)
         # Assign default values

--- a/test/test_compref.py
+++ b/test/test_compref.py
@@ -10,10 +10,9 @@ SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 class TestComponentReference(unittest.TestCase):
 
     def test_create(self):
-        identity = 'https://github.com/synbiodex/pysbol3/participation1'
         in_child_of = 'https://github.com/synbiodex/pysbol3/subcomponent'
         feature = 'https://github.com/synbiodex/pysbol3/other_feature'
-        comp_ref = sbol3.ComponentReference(identity, in_child_of, feature)
+        comp_ref = sbol3.ComponentReference(in_child_of, feature)
         self.assertIsNotNone(comp_ref)
         self.assertEqual(in_child_of, comp_ref.in_child_of)
         self.assertEqual(feature, comp_ref.feature)

--- a/test/test_extdef.py
+++ b/test/test_extdef.py
@@ -10,13 +10,11 @@ SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 class TestExternallyDefined(unittest.TestCase):
 
     def test_create(self):
-        display_id = 'CaCl2'
         types = ['https://identifiers.org/SBO:0000247']
         definition = 'https://identifiers.org/CHEBI:3312'
-        ext_def = sbol3.ExternallyDefined(display_id, types, definition)
+        ext_def = sbol3.ExternallyDefined(types, definition)
         self.assertEqual(definition, ext_def.definition)
         self.assertCountEqual(types, ext_def.types)
-        self.assertEqual(display_id, ext_def.display_id)
 
     def test_read_from_file(self):
         test_file = os.path.join(SBOL3_LOCATION, 'measurement_entity',

--- a/test/test_interaction.py
+++ b/test/test_interaction.py
@@ -8,11 +8,9 @@ import sbol3
 class TestInteraction(unittest.TestCase):
 
     def test_create(self):
-        display_id = 'interaction1'
         types = [sbol3.SBO_INHIBITION]
-        interaction = sbol3.Interaction(display_id, types)
+        interaction = sbol3.Interaction(types)
         self.assertIsNotNone(interaction)
-        self.assertEqual(display_id, interaction.display_id)
         self.assertEqual(types, interaction.types)
 
     def test_read(self):

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -10,7 +10,7 @@ SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 class TestInterface(unittest.TestCase):
 
     def test_create(self):
-        interface = sbol3.Interface('interface1')
+        interface = sbol3.Interface()
         self.assertIsNotNone(interface)
 
     def test_read_from_file(self):

--- a/test/test_localsub.py
+++ b/test/test_localsub.py
@@ -6,19 +6,16 @@ import sbol3
 class TestLocalSubComponent(unittest.TestCase):
 
     def test_create(self):
-        display_id = 'local1'
         types = [sbol3.SBO_DNA]
-        lsc = sbol3.LocalSubComponent(display_id, types)
+        lsc = sbol3.LocalSubComponent(types)
         self.assertIsNotNone(lsc)
         self.assertEqual(types, lsc.types)
-        self.assertEqual(display_id, lsc.display_id)
         self.assertEqual([], lsc.locations)
 
     def test_validation(self):
-        display_id = 'local1'
         types = []
         with self.assertRaises(sbol3.ValidationError):
-            sbol3.LocalSubComponent(display_id, types)
+            sbol3.LocalSubComponent(types)
 
 
 if __name__ == '__main__':

--- a/test/test_location.py
+++ b/test/test_location.py
@@ -8,7 +8,7 @@ class TestRange(unittest.TestCase):
     def test_creation(self):
         start = 1
         end = 10
-        r = sbol3.Range('r1', start, end)
+        r = sbol3.Range(start, end)
         self.assertIsNotNone(r)
         self.assertEqual(start, r.start)
         self.assertEqual(end, r.end)
@@ -17,19 +17,19 @@ class TestRange(unittest.TestCase):
         start = 0
         end = 10
         with self.assertRaises(sbol3.ValidationError):
-            sbol3.Range('r1', start, end)
+            sbol3.Range(start, end)
         start = 1
         end = 0
         with self.assertRaises(sbol3.ValidationError):
-            sbol3.Range('r1', start, end)
+            sbol3.Range(start, end)
         # end must be >= start
         start = 10
         end = 9
         with self.assertRaises(sbol3.ValidationError):
-            sbol3.Range('r1', start, end)
+            sbol3.Range(start, end)
         start = 7
         end = 7
-        r = sbol3.Range('r1', start, end)
+        r = sbol3.Range(start, end)
         self.assertEqual(start, r.start)
         self.assertEqual(end, r.end)
 
@@ -38,11 +38,11 @@ class TestCut(unittest.TestCase):
 
     def test_creation(self):
         at = 1
-        cut = sbol3.Cut('cut1', at)
+        cut = sbol3.Cut(at)
         self.assertIsNotNone(cut)
         self.assertEqual(at, cut.at)
         at = 0
-        cut = sbol3.Cut('cut1', at)
+        cut = sbol3.Cut(at)
         self.assertIsNotNone(cut)
         self.assertEqual(at, cut.at)
 
@@ -50,14 +50,14 @@ class TestCut(unittest.TestCase):
         # At must be >= 0
         at = -1
         with self.assertRaises(sbol3.ValidationError):
-            sbol3.Cut('cut1', at)
+            sbol3.Cut(at)
 
 
 class TestEntireSequence(unittest.TestCase):
 
     def test_creation(self):
         # EntireSequence has no properties, so there isn't much to test here
-        es = sbol3.EntireSequence('es1')
+        es = sbol3.EntireSequence()
         self.assertIsNotNone(es)
 
 

--- a/test/test_om_unit.py
+++ b/test/test_om_unit.py
@@ -10,19 +10,17 @@ SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 class TestMeasure(unittest.TestCase):
 
     def test_create(self):
-        display_id = 'measure1'
         unit = 'https://sbolstandard.org/examples/millimolePerLitre'
         value = 0.1
         types = ['https://identifiers.org/SBO:0000196',
                  'https://identifiers.org/SBO:0000197']
-        measure = sbol3.Measure(display_id, value, unit)
+        measure = sbol3.Measure(value, unit)
         measure.types = types
         self.assertIsNotNone(measure)
         self.assertIsInstance(measure, sbol3.Measure)
         self.assertEqual(value, measure.value)
         self.assertCountEqual(types, measure.types)
         self.assertEqual(unit, measure.unit)
-        self.assertEqual(display_id, measure.display_id)
 
     def test_read_from_file(self):
         test_file = os.path.join(SBOL3_LOCATION, 'measurement_entity',

--- a/test/test_participation.py
+++ b/test/test_participation.py
@@ -10,9 +10,8 @@ SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 class TestParticipation(unittest.TestCase):
 
     def test_create(self):
-        identity = 'https://github.com/synbiodex/pysbol3/participation1'
         participant = 'https://github.com/synbiodex/pysbol3/participant1'
-        p = sbol3.Participation(identity, [sbol3.SBO_INHIBITOR], participant)
+        p = sbol3.Participation([sbol3.SBO_INHIBITOR], participant)
         self.assertIsNotNone(p)
         self.assertEqual([sbol3.SBO_INHIBITOR], p.roles)
         self.assertEqual(participant, p.participant)

--- a/test/test_provenance.py
+++ b/test/test_provenance.py
@@ -34,10 +34,8 @@ class TestAssociation(unittest.TestCase):
 
     def test_create(self):
         agent = sbol3.Agent('agent')
-        display_id = 'association'
-        association = sbol3.Association(display_id, agent)
+        association = sbol3.Association(agent)
         self.assertIsNotNone(association)
-        self.assertEqual(display_id, association.display_id)
         self.assertEqual([], association.roles)
         self.assertEqual(None, association.plan)
         self.assertEqual(agent.identity, association.agent)
@@ -58,10 +56,8 @@ class TestUsage(unittest.TestCase):
 
     def test_create(self):
         agent = sbol3.Agent('agent')
-        display_id = 'usage'
-        usage = sbol3.Usage(display_id, agent.identity)
+        usage = sbol3.Usage(agent.identity)
         self.assertIsNotNone(usage)
-        self.assertEqual(display_id, usage.display_id)
         self.assertEqual(agent.identity, usage.entity)
         self.assertEqual([], usage.roles)
 

--- a/test/test_seqfeat.py
+++ b/test/test_seqfeat.py
@@ -6,18 +6,15 @@ import sbol3
 class TestSequenceFeature(unittest.TestCase):
 
     def test_create(self):
-        display_id = 'seqfeat1'
         es1 = sbol3.EntireSequence('es1')
         locations = [es1]
-        sf = sbol3.SequenceFeature(display_id, locations)
-        self.assertEqual(display_id, sf.display_id)
+        sf = sbol3.SequenceFeature(locations)
         self.assertEqual(locations, sf.locations)
 
     def test_validation(self):
-        display_id = 'seqfeat1'
         locations = []
         with self.assertRaises(sbol3.ValidationError):
-            sbol3.SequenceFeature(display_id, locations)
+            sbol3.SequenceFeature(locations)
 
 
 if __name__ == '__main__':

--- a/test/test_seqfeat.py
+++ b/test/test_seqfeat.py
@@ -6,7 +6,7 @@ import sbol3
 class TestSequenceFeature(unittest.TestCase):
 
     def test_create(self):
-        es1 = sbol3.EntireSequence('es1')
+        es1 = sbol3.EntireSequence()
         locations = [es1]
         sf = sbol3.SequenceFeature(locations)
         self.assertEqual(locations, sf.locations)

--- a/test/test_subcomponent.py
+++ b/test/test_subcomponent.py
@@ -7,16 +7,16 @@ class TestSubComponent(unittest.TestCase):
 
     def test_create(self):
         instance_of = sbol3.Component('comp1', sbol3.SBO_DNA)
-        sc1 = sbol3.SubComponent('sc1', instance_of)
+        sc1 = sbol3.SubComponent(instance_of)
         self.assertIsNotNone(sc1)
         self.assertEqual(instance_of.identity, sc1.instance_of)
-        sc2 = sbol3.SubComponent('sc2', instance_of.identity)
+        sc2 = sbol3.SubComponent(instance_of.identity)
         self.assertEqual(instance_of.identity, sc2.instance_of)
 
     def test_invalid_create(self):
         # SubComponent requires an `instance_of` argument
-        with self.assertRaises(TypeError):
-            sbol3.SubComponent('sc1')
+        with self.assertRaises(sbol3.ValidationError):
+            sbol3.SubComponent('')
 
 
 if __name__ == '__main__':

--- a/test/test_varcomp.py
+++ b/test/test_varcomp.py
@@ -6,7 +6,7 @@ import sbol3
 class TestVariableComponent(unittest.TestCase):
 
     def test_create(self):
-        vc = sbol3.VariableComponent('vc1')
+        vc = sbol3.VariableComponent()
         self.assertIsNotNone(vc)
         # Verify the correct default values
         self.assertEqual(sbol3.SBOL_ZERO_OR_MORE, vc.cardinality)
@@ -15,7 +15,7 @@ class TestVariableComponent(unittest.TestCase):
     def test_invalid_create(self):
         my_cardinality = 'https://github.com/synbiodex/pysbol3#someNumber'
         with self.assertRaises(sbol3.ValidationError):
-            vc = sbol3.VariableComponent('vc1', cardinality=my_cardinality)
+            vc = sbol3.VariableComponent(cardinality=my_cardinality)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
SBOL compliant URIs will overwrite any identity or display_id in a child object (i.e. non-TopLevel) so allow creation without passing an identity or display_id to the constructor. When these classes are added to a parent object they will be assigned and identity and display_id according to the SBOL compliant URI rules.