### PR TITLE
Improve compliant URL handling

### DIFF
--- a/sbol3/feature.py
+++ b/sbol3/feature.py
@@ -9,7 +9,7 @@ class Feature(Identified, abc.ABC):
 
     def __init__(self, name: str, type_uri: str) -> None:
         super().__init__(name, type_uri)
-        self.role = URIProperty(self, SBOL_ROLE, 0, math.inf)
+        self.roles = URIProperty(self, SBOL_ROLE, 0, math.inf)
         self.orientation = URIProperty(self, SBOL_ORIENTATION, 0, 1)
 
     def validate(self) -> None:

--- a/test/test_ownedobject.py
+++ b/test/test_ownedobject.py
@@ -73,6 +73,19 @@ class TestOwnedObject(unittest.TestCase):
         expected2 = posixpath.join(comp.identity, 'Constraint2')
         self.assertEqual(expected2, comp.constraints[1].identity)
 
+    def test_cascade_identity(self):
+        # Test that updating identity of an owned object cascades
+        # to child owned objects
+        c1 = sbol3.Component('c1', sbol3.SBO_DNA)
+        seq = sbol3.Sequence('seq1')
+        loc = sbol3.EntireSequence(seq)
+        seq_feature = sbol3.SequenceFeature([loc])
+        c1.features.append(seq_feature)
+        self.assertIsNotNone(seq_feature.identity)
+        # identity should cascade down to the location after it
+        # is set on the sequence feature
+        self.assertIsNotNone(loc.identity)
+
     # TODO: Write tests for adding via a slice
     #       comp.constraints[0:1] = sbol3.Constraint('foo')
 

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -91,7 +91,7 @@ class TestRoundTrip(unittest.TestCase):
                 # Skip file types we don't know
                 # print(f'Skipping {f} of type {rdf_type}')
                 continue
-            print(f'Reading {f}')
+            # print(f'Reading {f}')
             doc = sbol3.Document()
             doc.read(f, rdf_type)
 


### PR DESCRIPTION
When an object is added to a parent, cascade the new identity
to all child objects.