### PR TITLE
Avoid overwriting an annotation

### DIFF
--- a/sbol3/property_base.py
+++ b/sbol3/property_base.py
@@ -17,7 +17,9 @@ class Property(abc.ABC):
             validation_rules = []
         self.validation_rules = validation_rules
         # Initialize the storage for this property
-        self._storage()[self.property_uri] = []
+        # Do not overwrite a value if already present (see issue #76)
+        if self.property_uri not in self._storage():
+            self._storage()[self.property_uri] = []
 
     def _storage(self) -> Dict[str, list]:
         return self.property_owner._properties

--- a/test/test_annotation.py
+++ b/test/test_annotation.py
@@ -1,0 +1,38 @@
+import os
+import tempfile
+import unittest
+
+import sbol3
+
+
+class TestAnnotation(unittest.TestCase):
+
+    def test_annotation(self):
+        # Create custom annotation
+        annotation_uri = 'http://example.org/boolean_property'
+        annotation_value = 'foo'
+
+        c = sbol3.Component('c1', sbol3.SBO_DNA)
+        c.annotation = sbol3.TextProperty(c, annotation_uri,
+                                          0, 1, [])
+        c.annotation = annotation_value
+        self.assertEqual(annotation_value, c.annotation)
+
+        doc = sbol3.Document()
+        doc.add(c)
+        doc2 = sbol3.Document()
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            test_file = os.path.join(tmpdirname, 'annotation.xml')
+            doc.write(test_file, sbol3.RDF_XML)
+            # Roundtrip
+            doc2.read(test_file, sbol3.RDF_XML)
+
+        # Recover annotation
+        c = doc2.find('c1')
+        c.annotation = sbol3.TextProperty(c, annotation_uri,
+                                          0, 1, [])
+        self.assertEqual(annotation_value, c.annotation)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When allocation property storage do not overwrite an existing value if present. This allows annotations to be read from file prior to being defined.

Fixes #76 