### PR TITLE
Clarify some constructor arguments

### DIFF
--- a/sbol3/interaction.py
+++ b/sbol3/interaction.py
@@ -6,12 +6,12 @@ from . import *
 
 class Interaction(Identified):
 
-    def __init__(self, interaction_type: List[str],
+    def __init__(self, interaction_types: List[str],
                  *, name: str = None,
                  type_uri: str = SBOL_INTERACTION) -> None:
         super().__init__(name, type_uri)
         self.types = URIProperty(self, SBOL_TYPE, 1, math.inf,
-                                 initial_value=interaction_type)
+                                 initial_value=interaction_types)
         self.participations = OwnedObject(self, SBOL_PARTICIPATIONS, 0, math.inf)
 
     def validate(self) -> None:

--- a/sbol3/participation.py
+++ b/sbol3/participation.py
@@ -6,13 +6,13 @@ from .typing import *
 
 class Participation(Identified):
 
-    def __init__(self, role: List[str],
+    def __init__(self, roles: List[str],
                  participant: Union[SBOLObject, str],
                  *, name: str = None,
                  type_uri: str = SBOL_PARTCIPATION) -> None:
         super().__init__(name, type_uri)
         self.roles: uri_list = URIProperty(self, SBOL_ROLE, 1, math.inf,
-                                           initial_value=role)
+                                           initial_value=roles)
         self.participant = ReferencedObject(self, SBOL_PARTICIPANT, 1, 1,
                                             initial_value=participant)
         self.validate()


### PR DESCRIPTION
Make it clear for Participation and Interaction constructor
arguments that the expected values are lists, not singletons.

This is in support of the COMBINE 2020 tutorial.