### PR TITLE
Change homespace to namespace

### DIFF
--- a/examples/circuit.py
+++ b/examples/circuit.py
@@ -3,7 +3,7 @@ import sbol3
 # This example encodes a circuit depicted at
 # https://github.com/BuildACell/BioCRNPyler/blob/master/README.md
 
-sbol3.set_homespace('https://github.com/BuildACell/BioCRNPyler')
+sbol3.set_namespace('https://github.com/BuildACell/BioCRNPyler')
 
 # Ptet promoter
 ptet = sbol3.Component('pTetR', sbol3.SBO_DNA)
@@ -29,28 +29,19 @@ gfp.description = 'GFP Coding Sequence'
 
 # Wrap it together
 circuit = sbol3.Component('circuit', sbol3.SBO_DNA)
-ptet_sc = sbol3.SubComponent('ptet', ptet)
-op1_sc = sbol3.SubComponent('op1', op1)
-utr1_sc = sbol3.SubComponent('UTR1', utr1)
-gfp_sc = sbol3.SubComponent('GFP', gfp)
+ptet_sc = sbol3.SubComponent(ptet)
+op1_sc = sbol3.SubComponent(op1)
+utr1_sc = sbol3.SubComponent(utr1)
+gfp_sc = sbol3.SubComponent(gfp)
 
 # circuit.features can be set and appended to like any Python list
 circuit.features = [ptet_sc, op1_sc]
 circuit.features += [utr1_sc]
 circuit.features.append(gfp_sc)
 
-
-def make_constraint(name, subj, restriction, obj):
-    c = sbol3.Constraint(name)
-    c.subject = subj
-    c.restriction = restriction
-    c.object = obj
-    return c
-
-
-circuit.constraints = [make_constraint('c1', ptet_sc, sbol3.SBOL_PRECEDES, op1_sc),
-                       make_constraint('c2', op1_sc, sbol3.SBOL_PRECEDES, utr1_sc),
-                       make_constraint('c3', utr1_sc, sbol3.SBOL_PRECEDES, gfp_sc)]
+circuit.constraints = [sbol3.Constraint(sbol3.SBOL_PRECEDES, ptet_sc, op1_sc),
+                       sbol3.Constraint(sbol3.SBOL_PRECEDES, op1_sc, utr1_sc),
+                       sbol3.Constraint(sbol3.SBOL_PRECEDES, utr1_sc, gfp_sc)]
 
 doc = sbol3.Document()
 # TODO: Enhancement: doc.addAll([ptet, op1, utr1, ...])

--- a/sbol3/__init__.py
+++ b/sbol3/__init__.py
@@ -1,5 +1,7 @@
 from .constants import *
-from .config import set_defaults, get_homespace, set_homespace
+from .config import set_defaults, get_namespace, set_namespace
+# get_homespace and set_homespace are deprecated and included for backward compatibility
+from .config import get_homespace, set_homespace
 from .error import *
 from .object import SBOLObject
 from .property_base import Property, SingletonProperty, ListProperty

--- a/sbol3/config.py
+++ b/sbol3/config.py
@@ -1,28 +1,39 @@
+import warnings
 from urllib.parse import urlparse
 
 # We probably want to turn this into a dict like the configuration dict
 # in pySBOL2. When we have more variables to store, let's change this
 # to a dict.
-SBOL3_HOMESPACE = ''
+SBOL3_NAMESPACE = ''
 
 
-def get_homespace() -> str:
-    return SBOL3_HOMESPACE
+def get_namespace() -> str:
+    return SBOL3_NAMESPACE
 
 
-def set_homespace(homespace: str) -> None:
-    parsed = urlparse(homespace)
-    if parsed.scheme and parsed.netloc and parsed.path:
-        global SBOL3_HOMESPACE
-        SBOL3_HOMESPACE = homespace
+def set_namespace(namespace: str) -> None:
+    parsed = urlparse(namespace)
+    if parsed.scheme and parsed.netloc:
+        global SBOL3_NAMESPACE
+        SBOL3_NAMESPACE = namespace
     else:
-        raise ValueError(f'Expected URL found {homespace}')
+        raise ValueError(f'Expected URL found {namespace}')
 
 
 def set_defaults() -> None:
     """Restores configuration to factory settings.
     """
-    set_homespace('http://example.com/sbol3/')
+    set_namespace('http://example.com/sbol3/')
 
 
 set_defaults()
+
+
+def set_homespace(homespace: str) -> None:
+    warnings.warn('Use set_namespace instead', DeprecationWarning)
+    return set_namespace(homespace)
+
+
+def get_homespace() -> str:
+    warnings.warn('Use get_namespace instead', DeprecationWarning)
+    return get_namespace()

--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -52,10 +52,10 @@ class SBOLObject:
         """Make an identity from the given name.
 
         If the name is a URL, that can be the identity. Or perhaps it
-        needs to start with the default URI prefix (i.e. homespace).
+        needs to start with the default URI prefix (i.e. namespace).
 
         If the name is not a URL, prefix it with the default URI prefix
-        (homespace) and verify that the result is a valid URL.
+        (namespace) and verify that the result is a valid URL.
 
         We do not support UUIDs, which are legal SBOL identifiers.
         """
@@ -70,8 +70,8 @@ class SBOLObject:
             return str(identity_uuid)
         except ValueError:
             pass
-        # Not a URL or a UUID, so append to the homespace
-        base_uri = get_homespace()
+        # Not a URL or a UUID, so append to the namespace
+        base_uri = get_namespace()
         if base_uri.endswith('#'):
             return base_uri + name
         else:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -11,10 +11,16 @@ class TestConfig(unittest.TestCase):
     def setUp(self) -> None:
         sbol3.set_defaults()
 
-    def test_homespace(self):
+    def test_namespace(self):
         base_uri = 'https://github.com/synbiodex/pysbol3'
-        sbol3.set_homespace(base_uri)
-        self.assertEqual(base_uri, sbol3.get_homespace())
+        sbol3.set_namespace(base_uri)
+        self.assertEqual(base_uri, sbol3.get_namespace())
+
+        # Example from SBOL 3.0 Section 5.1 (page 12)
+        # See issue #80
+        base_uri = 'https://synbiohub.org'
+        sbol3.set_namespace(base_uri)
+        self.assertEqual(base_uri, sbol3.get_namespace())
 
 
 if __name__ == '__main__':

--- a/test/test_identified.py
+++ b/test/test_identified.py
@@ -13,7 +13,6 @@ class TestIdentified(unittest.TestCase):
         sbol3.set_defaults()
 
     def test_display_id(self):
-        # self.assertEqual(None, sbol3.get_homespace())
         c1_display_id = 'c1'
         c = sbol3.Component(c1_display_id, sbol3.SBO_DNA)
         self.assertEqual(c1_display_id, c.display_id)
@@ -33,13 +32,13 @@ class TestIdentified(unittest.TestCase):
         #   * Test by passing display_id to constructor
         #   * Test by having display_id deduced from identity
         c1_display_id = 'c1'
-        c1_identity = posixpath.join(sbol3.get_homespace(), c1_display_id)
+        c1_identity = posixpath.join(sbol3.get_namespace(), c1_display_id)
         c1 = sbol3.Component(c1_display_id, sbol3.SBO_DNA)
         self.assertEqual(c1_display_id, c1.display_id)
         self.assertEqual(c1_identity, c1.identity)
         # Now test identity and display_id from a URL-type URI
         c2_display_id = 'c2'
-        c2_identity = posixpath.join(sbol3.get_homespace(), c2_display_id)
+        c2_identity = posixpath.join(sbol3.get_namespace(), c2_display_id)
         c2 = sbol3.Component(c2_identity, sbol3.SBO_DNA)
         self.assertEqual(c2_display_id, c2.display_id)
         self.assertEqual(c2_identity, c2.identity)
@@ -48,7 +47,7 @@ class TestIdentified(unittest.TestCase):
         # Verify that a UUID can be used as an identity and that
         # the object does not have a display_id since the identity
         # is not a URL
-        identity = str(uuid.uuid5(uuid.NAMESPACE_URL, sbol3.get_homespace()))
+        identity = str(uuid.uuid5(uuid.NAMESPACE_URL, sbol3.get_namespace()))
         c = sbol3.Component(identity, sbol3.SBO_DNA)
         self.assertEqual(identity, c.identity)
         self.assertIsNone(c.display_id)

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -11,8 +11,8 @@ class TestObject(unittest.TestCase):
 
     def test_trailing_slash(self):
         # A trailing slash on an object's identity should automatically be removed
-        sbol3.set_homespace('http://example.org/sbol3')
-        slash_identity = posixpath.join(sbol3.get_homespace(), 'c1', '')
+        sbol3.set_namespace('http://example.org/sbol3')
+        slash_identity = posixpath.join(sbol3.get_namespace(), 'c1', '')
         self.assertTrue(slash_identity.endswith(posixpath.sep))
         c = sbol3.Component(slash_identity, sbol3.SBO_DNA)
         identity = slash_identity.strip(posixpath.sep)

--- a/test/test_ownedobject.py
+++ b/test/test_ownedobject.py
@@ -13,7 +13,7 @@ class TestOwnedObject(unittest.TestCase):
                                 'http://example.com/fake1',
                                 'http://example.com/fake2',
                                 name=con1_id)
-        expected = posixpath.join(sbol3.get_homespace(), con1_id)
+        expected = posixpath.join(sbol3.get_namespace(), con1_id)
         # The constraint's identity and display_id will be overwritten as
         # part of the append operation. SBOL Compliant URIs (identities)
         # use the class of the object and a counter to generate the
@@ -33,7 +33,7 @@ class TestOwnedObject(unittest.TestCase):
                                 'http://example.com/fake1',
                                 'http://example.com/fake2',
                                 name=con1_id)
-        expected = posixpath.join(sbol3.get_homespace(), con1_id)
+        expected = posixpath.join(sbol3.get_namespace(), con1_id)
         expected2 = posixpath.join(comp.identity, 'Constraint1')
         self.assertNotEqual(expected, expected2)
         self.assertEqual(expected, con1.identity)


### PR DESCRIPTION
Start migrating to namespaces to support the namespace change(s)
coming in SBOL 3.0.1. Allow namespaces to have no path to
comply with the standard.

Fixes #80 