### PR TITLE
Enable round-tripping for custom classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ missing features.
 Use pip to install the library:
 
 ```
-pip install git+https://github.com/SynBioDex/pySBOL3
+pip install sbol3
 ```
 
 ## Documentation

--- a/sbol3/custom.py
+++ b/sbol3/custom.py
@@ -5,11 +5,11 @@ from . import *
 
 class CustomIdentified(Identified):
 
-    def __init__(self, custom_type: str = None, *, name: str = None,
-                 type_uri: str = SBOL_IDENTIFIED) -> None:
-        super().__init__(name, type_uri)
+    def __init__(self, type_uri: str = None, *, name: str = None,
+                 sbol_type_uri: str = SBOL_IDENTIFIED) -> None:
+        super().__init__(name, sbol_type_uri)
         self.rdf_type = URIProperty(self, rdflib.RDF.type, 1, 1,
-                                    initial_value=custom_type)
+                                    initial_value=type_uri)
         self.validate()
 
     def validate(self) -> None:
@@ -20,11 +20,11 @@ class CustomIdentified(Identified):
 
 class CustomTopLevel(TopLevel):
 
-    def __init__(self, name: str = None, custom_type: str = None,
-                 *, type_uri: str = SBOL_TOP_LEVEL) -> None:
-        super().__init__(name, type_uri)
+    def __init__(self, name: str = None, type_uri: str = None,
+                 *, sbol_type_uri: str = SBOL_TOP_LEVEL) -> None:
+        super().__init__(name, sbol_type_uri)
         self.rdf_type = URIProperty(self, rdflib.RDF.type, 1, 1,
-                                    initial_value=custom_type)
+                                    initial_value=type_uri)
         self.validate()
 
     def validate(self) -> None:

--- a/test/test_custom.py
+++ b/test/test_custom.py
@@ -1,3 +1,6 @@
+import math
+import os
+import tempfile
 import unittest
 
 import rdflib
@@ -5,7 +8,43 @@ import rdflib
 import sbol3
 
 
+PYSBOL3_CUSTOM_TOP = 'https://github.com/synbiodex/pysbol3#customTop'
+PYSBOL3_CUSTOM_BOOL = 'https://github.com/synbiodex/pysbol3#customBool'
+PYSBOL3_CUSTOM_CHILD = 'https://github.com/synbiodex/pysbol3#customChildren'
+PYSBOL3_CUSTOM_IDENTIFIED = 'https://github.com/synbiodex/pysbol3#customIdentified'
+PYSBOL3_CUSTOM_INT = 'https://github.com/synbiodex/pysbol3#customInt'
+
+
+class CustomTopClass(sbol3.CustomTopLevel):
+    def __init__(self, name, type_uri=PYSBOL3_CUSTOM_TOP):
+        super().__init__(name, type_uri)
+        # Also test the boolean list while we're here
+        self.foo_bool = sbol3.BooleanProperty(self, PYSBOL3_CUSTOM_BOOL,
+                                              0, math.inf)
+        self.children = sbol3.OwnedObject(self, PYSBOL3_CUSTOM_CHILD, 0, math.inf)
+
+
+class CustomIdentifiedClass(sbol3.CustomIdentified):
+    def __init__(self, type_uri=PYSBOL3_CUSTOM_IDENTIFIED, name=None):
+        super().__init__(type_uri, name=name)
+        # Also test the int list while we're here
+        self.foo_int = sbol3.IntProperty(self, PYSBOL3_CUSTOM_INT,
+                                         0, math.inf)
+
+
 class TestCustomTopLevel(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        sbol3.Document.register_builder(PYSBOL3_CUSTOM_TOP, CustomTopClass)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # Go behind the scenes to clean up
+        # TODO: should there be a way to deregister a builder?
+        store = sbol3.Document._uri_type_map
+        if PYSBOL3_CUSTOM_TOP in store:
+            del store[PYSBOL3_CUSTOM_TOP]
 
     def test_create(self):
         custom_type = 'https://github.com/synbiodex/pysbol3/CustomType'
@@ -17,13 +56,49 @@ class TestCustomTopLevel(unittest.TestCase):
     # TODO: We really want to verify the serialization of the custom top
     #       level as well. There is no Document.writeString() yet.
 
+    def test_round_trip(self):
+        # Test the boolean list property, which is not used by the
+        # core SBOL 3 data model
+        obj_name = 'bool_test'
+        obj = CustomTopClass(obj_name)
+        self.assertEqual([], obj.foo_bool)
+        obj.foo_bool.append(True)
+        obj.foo_bool.append(False)
+        self.assertEqual([True, False], obj.foo_bool)
+        doc = sbol3.Document()
+        doc.add(obj)
+        doc2 = sbol3.Document()
+        # Round trip the document
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            test_file = os.path.join(tmpdirname, 'custom.nt')
+            doc.write(test_file, sbol3.NTRIPLES)
+            doc2.read(test_file, sbol3.NTRIPLES)
+        obj2 = doc2.find(obj_name)
+        # The lists are necessarily unordered because of RDF
+        # Compare specially
+        self.assertCountEqual([True, False], obj2.foo_bool)
+
 
 class TestCustomIdentified(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        sbol3.Document.register_builder(PYSBOL3_CUSTOM_TOP, CustomTopClass)
+        sbol3.Document.register_builder(PYSBOL3_CUSTOM_IDENTIFIED, CustomIdentifiedClass)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # Go behind the scenes to clean up
+        # TODO: should there be a way to deregister a builder?
+        store = sbol3.Document._uri_type_map
+        for uri in [PYSBOL3_CUSTOM_TOP, PYSBOL3_CUSTOM_IDENTIFIED]:
+            if uri in store:
+                del store[uri]
 
     def test_create(self):
         custom_type = 'https://github.com/synbiodex/pysbol3/CustomType'
         ctl = sbol3.CustomIdentified(name='custom1',
-                                     custom_type=custom_type)
+                                     type_uri=custom_type)
         # Go behind the scenes to verify
         self.assertEqual(rdflib.URIRef(custom_type),
                          ctl._properties[rdflib.RDF.type][0])
@@ -31,6 +106,32 @@ class TestCustomIdentified(unittest.TestCase):
     # TODO: We really want to verify the serialization of the custom
     #       identified as well. We need to attach it to a top level
     #       to see that work.
+
+    def test_round_trip(self):
+        # Test the int list property, which is not used by the
+        # core SBOL 3 data model
+        obj = CustomIdentifiedClass()
+        self.assertEqual([], obj.foo_int)
+        obj.foo_int.append(7)
+        obj.foo_int.append(14)
+        self.assertEqual([7, 14], obj.foo_int)
+
+        tl_name = 'my_obj'
+        tl = CustomTopClass(tl_name)
+        tl.children.append(obj)
+        doc = sbol3.Document()
+        doc.add(tl)
+        doc2 = sbol3.Document()
+        # Round trip the document
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            test_file = os.path.join(tmpdirname, 'custom.nt')
+            doc.write(test_file, sbol3.NTRIPLES)
+            doc2.read(test_file, sbol3.NTRIPLES)
+        tl2 = doc2.find(tl_name)
+        obj2 = tl2.children[0]
+        # The lists are necessarily unordered because of RDF
+        # Compare specially
+        self.assertCountEqual([7, 14], obj2.foo_int)
 
 
 if __name__ == '__main__':

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -1,7 +1,9 @@
+import math
 import unittest
+
 import rdflib
+
 import sbol3
-from math import inf
 
 
 class TestProperty(unittest.TestCase):
@@ -48,12 +50,12 @@ class TestProperty(unittest.TestCase):
     def test_bounds(self):
         c = sbol3.Component('c1', sbol3.SBO_DNA)
         c.boolean_attribute = sbol3.BooleanProperty(c, 'http://example.org#foo',
-                                                    0, inf, [])
+                                                    0, math.inf, [])
         self.assertTrue(hasattr(c.boolean_attribute, '__iter__'))
         with self.assertRaises(TypeError):
             c.boolean_attribute = True
         c.int_attribute = sbol3.IntProperty(c, 'http://example.org#foo',
-                                            0, inf, [])
+                                            0, math.inf, [])
         self.assertTrue(hasattr(c.int_attribute, '__iter__'))
         with self.assertRaises(TypeError):
             c.int_attribute = 0


### PR DESCRIPTION
Allow custom classes to be properly constructed when reading
SBOL files via register_builder(). Ensure that builders are
always called with the same keyword arguments.

Progress towards #7 