### PR TITLE
Make OM and PROV classes extend Custom classes

### DIFF
--- a/sbol3/custom.py
+++ b/sbol3/custom.py
@@ -7,10 +7,9 @@ class CustomIdentified(Identified):
 
     def __init__(self, type_uri: str = None, *, name: str = None,
                  sbol_type_uri: str = SBOL_IDENTIFIED) -> None:
-        super().__init__(name, sbol_type_uri)
+        super().__init__(name, type_uri)
         self.rdf_type = URIProperty(self, rdflib.RDF.type, 1, 1,
-                                    initial_value=type_uri)
-        self.validate()
+                                    initial_value=sbol_type_uri)
 
     def validate(self) -> None:
         super().validate()
@@ -22,10 +21,9 @@ class CustomTopLevel(TopLevel):
 
     def __init__(self, name: str = None, type_uri: str = None,
                  *, sbol_type_uri: str = SBOL_TOP_LEVEL) -> None:
-        super().__init__(name, sbol_type_uri)
+        super().__init__(name, type_uri)
         self.rdf_type = URIProperty(self, rdflib.RDF.type, 1, 1,
-                                    initial_value=type_uri)
-        self.validate()
+                                    initial_value=sbol_type_uri)
 
     def validate(self) -> None:
         super().validate()

--- a/sbol3/om_prefix.py
+++ b/sbol3/om_prefix.py
@@ -4,7 +4,7 @@ import math
 from . import *
 
 
-class Prefix(TopLevel, abc.ABC):
+class Prefix(CustomTopLevel, abc.ABC):
     """om:Prefix is an abstract base class.
 
     See Appendix A Section A.2 of the SBOL 3.0 specificiation.
@@ -41,6 +41,7 @@ class SIPrefix(Prefix):
     def __init__(self, name: str, symbol: str, label: str,
                  factor: float, *, type_uri: str = OM_SI_PREFIX) -> None:
         super().__init__(name, symbol, label, factor, type_uri)
+        self.validate()
 
 
 def build_si_prefix(name: str, *, type_uri: str = OM_SI_PREFIX) -> SBOLObject:
@@ -61,6 +62,7 @@ class BinaryPrefix(Prefix):
     def __init__(self, name: str, symbol: str, label: str,
                  factor: float, *, type_uri: str = OM_BINARY_PREFIX) -> None:
         super().__init__(name, symbol, label, factor, type_uri)
+        self.validate()
 
 
 def build_binary_prefix(name: str, *, type_uri: str = OM_BINARY_PREFIX) -> SBOLObject:

--- a/sbol3/om_unit.py
+++ b/sbol3/om_unit.py
@@ -6,7 +6,7 @@ from . import *
 from .om_prefix import Prefix
 
 
-class Unit(TopLevel, abc.ABC):
+class Unit(CustomTopLevel, abc.ABC):
     """om:Unit is an abstract base class.
 
     See Appendix A Section A.2 of the SBOL 3.0 specificiation.
@@ -27,12 +27,12 @@ class Unit(TopLevel, abc.ABC):
         self.long_comment = TextProperty(self, OM_LONG_COMMENT, 0, 1)
 
 
-class Measure(Identified):
+class Measure(CustomIdentified):
 
     def __init__(self, value: float, unit: str,
                  *, name: str = None,
                  type_uri: str = OM_MEASURE) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(name=name, type_uri=type_uri)
         self.value = FloatProperty(self, OM_HAS_NUMERICAL_VALUE, 1, 1,
                                    initial_value=value)
         self.types = URIProperty(self, SBOL_TYPE, 0, math.inf)

--- a/sbol3/provenance.py
+++ b/sbol3/provenance.py
@@ -4,11 +4,11 @@ from typing import Union
 from . import *
 
 
-class Usage(Identified):
+class Usage(CustomIdentified):
 
     def __init__(self, entity: str, *, name: str = None,
                  type_uri: str = PROV_USAGE) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(name=name, type_uri=type_uri)
         self.entity = URIProperty(self, PROV_ENTITY, 1, 1,
                                   initial_value=entity)
         self.roles = URIProperty(self, PROV_ROLES, 0, math.inf)
@@ -26,7 +26,7 @@ def build_usage(name: str, *, type_uri: str = PROV_USAGE) -> SBOLObject:
 Document.register_builder(PROV_USAGE, build_usage)
 
 
-class Agent(TopLevel):
+class Agent(CustomTopLevel):
 
     def __init__(self, name: str, *, type_uri: str = PROV_AGENT) -> None:
         super().__init__(name, type_uri)
@@ -36,7 +36,7 @@ class Agent(TopLevel):
 Document.register_builder(PROV_AGENT, Agent)
 
 
-class Plan(TopLevel):
+class Plan(CustomTopLevel):
 
     def __init__(self, name: str, *, type_uri: str = PROV_PLAN) -> None:
         super().__init__(name, type_uri)
@@ -46,12 +46,12 @@ class Plan(TopLevel):
 Document.register_builder(PROV_PLAN, Plan)
 
 
-class Association(Identified):
+class Association(CustomIdentified):
 
     def __init__(self, agent: Union[str, Identified],
                  *, name: str = None,
                  type_uri: str = PROV_ASSOCIATION) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(name=name, type_uri=type_uri)
         self.roles = URIProperty(self, PROV_ROLES, 0, math.inf)
         self.plan = ReferencedObject(self, PROV_PLANS, 0, 1)
         self.agent = ReferencedObject(self, PROV_AGENTS, 1, 1,
@@ -70,7 +70,7 @@ def build_association(name: str, *, type_uri: str = PROV_USAGE) -> SBOLObject:
 Document.register_builder(PROV_ASSOCIATION, build_association)
 
 
-class Activity(TopLevel):
+class Activity(CustomTopLevel):
 
     def __init__(self, name: str, *, type_uri: str = PROV_ACTIVITY) -> None:
         super().__init__(name, type_uri)

--- a/test/test_custom.py
+++ b/test/test_custom.py
@@ -49,8 +49,9 @@ class TestCustomTopLevel(unittest.TestCase):
     def test_create(self):
         custom_type = 'https://github.com/synbiodex/pysbol3/CustomType'
         ctl = sbol3.CustomTopLevel('custom1', custom_type)
+        self.assertEqual(custom_type, ctl.type_uri)
         # Go behind the scenes to verify
-        self.assertEqual(rdflib.URIRef(custom_type),
+        self.assertEqual(rdflib.URIRef(sbol3.SBOL_TOP_LEVEL),
                          ctl._properties[rdflib.RDF.type][0])
 
     # TODO: We really want to verify the serialization of the custom top
@@ -99,8 +100,9 @@ class TestCustomIdentified(unittest.TestCase):
         custom_type = 'https://github.com/synbiodex/pysbol3/CustomType'
         ctl = sbol3.CustomIdentified(name='custom1',
                                      type_uri=custom_type)
+        self.assertEqual(custom_type, ctl.type_uri)
         # Go behind the scenes to verify
-        self.assertEqual(rdflib.URIRef(custom_type),
+        self.assertEqual(rdflib.URIRef(sbol3.SBOL_IDENTIFIED),
                          ctl._properties[rdflib.RDF.type][0])
 
     # TODO: We really want to verify the serialization of the custom

--- a/test/test_ownedobject.py
+++ b/test/test_ownedobject.py
@@ -47,7 +47,7 @@ class TestOwnedObject(unittest.TestCase):
         tl.measure = m
         expected = posixpath.join(tl.identity, 'Measure1')
         self.assertIsNotNone(tl.measure.identity)
-        self.assertEqual(tl.measure.identity, expected)
+        self.assertEqual(expected, tl.measure.identity)
 
     def test_add_multiple_children(self):
         # Test that the the display_id and identity are overwritten


### PR DESCRIPTION
Measurement and Provenance classes in the om: and prov: namespaces should extend CustomTopLevel or CustomIdentified because their rdf:type attribute is outside the SBOL namespace.

There are [corresponding changes pending in SBOLTestSuite](https://github.com/SynBioDex/SBOLTestSuite/pull/29).

Closes #97 