### PR TITLE
Add Python 3.9 to CI builds

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,17 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.8, pypy3]
-        exclude:
+        # Default builds are on Ubuntu
+        os: [ubuntu-latest]
+        python-version: [3.6, 3.8, 3.9, pypy3]
+        include:
+	  # Also test on macOS and Windows using latest Python 3
           - os: macos-latest
-            python-version: 3.6
-          - os: macos-latest
-            python-version: pypy3
+            python-version: 3.x
           - os: windows-latest
-            python-version: 3.6
-          - os: windows-latest
-            python-version: pypy3
+            python-version: 3.x
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: [3.6, 3.8, 3.9, pypy3]
         include:
-	  # Also test on macOS and Windows using latest Python 3
+          # Also test on macOS and Windows using latest Python 3
           - os: macos-latest
             python-version: 3.x
           - os: windows-latest


### PR DESCRIPTION
Test the following OS/Python combinations:
* Ubuntu: 3.6, 3.8. 3.9, PyPy
* macOS: 3.x (latest minor version, currently 3.9)
* Windows: 3.x (latest minor version, currently 3.9)
