### PR TITLE
Change constructor arg "name" to "identity"

### DIFF
--- a/sbol3/attachment.py
+++ b/sbol3/attachment.py
@@ -3,9 +3,9 @@ from . import *
 
 class Attachment(TopLevel):
 
-    def __init__(self, name: str, source: str,
+    def __init__(self, identity: str, source: str,
                  *, type_uri: str = SBOL_ATTACHMENT):
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         self.source = URIProperty(self, SBOL_SOURCE, 1, 1,
                                   initial_value=source)
         self.format = URIProperty(self, SBOL_FORMAT, 0, 1)
@@ -22,9 +22,9 @@ class Attachment(TopLevel):
             raise ValidationError(message)
 
 
-def build_attachment(name: str, *, type_uri: str = SBOL_COMPONENT) -> SBOLObject:
+def build_attachment(identity: str, *, type_uri: str = SBOL_COMPONENT) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = Attachment(name, missing, type_uri=type_uri)
+    obj = Attachment(identity, missing, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[SBOL_SOURCE] = []
     return obj

--- a/sbol3/collection.py
+++ b/sbol3/collection.py
@@ -5,21 +5,21 @@ from . import *
 
 class Collection(TopLevel):
 
-    def __init__(self, name: str, *, type_uri: str = SBOL_COLLECTION) -> None:
-        super().__init__(name, type_uri)
+    def __init__(self, identity: str, *, type_uri: str = SBOL_COLLECTION) -> None:
+        super().__init__(identity, type_uri)
         self.members = ReferencedObject(self, SBOL_ORIENTATION, 0, math.inf)
 
 
 class Namespace(Collection):
 
-    def __init__(self, name: str, *, type_uri: str = SBOL_NAMESPACE) -> None:
-        super().__init__(name, type_uri=type_uri)
+    def __init__(self, identity: str, *, type_uri: str = SBOL_NAMESPACE) -> None:
+        super().__init__(identity, type_uri=type_uri)
 
 
 class Experiment(Collection):
 
-    def __init__(self, name: str, *, type_uri: str = SBOL_EXPERIMENT) -> None:
-        super().__init__(name, type_uri=type_uri)
+    def __init__(self, identity: str, *, type_uri: str = SBOL_EXPERIMENT) -> None:
+        super().__init__(identity, type_uri=type_uri)
 
 
 Document.register_builder(SBOL_COLLECTION, Collection)

--- a/sbol3/combderiv.py
+++ b/sbol3/combderiv.py
@@ -6,9 +6,9 @@ from . import *
 
 class CombinatorialDerivation(TopLevel):
 
-    def __init__(self, name: str, template: Union[Component, str],
+    def __init__(self, identity: str, template: Union[Component, str],
                  *, type_uri: str = SBOL_MODEL) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         self.strategy = URIProperty(self, SBOL_STRATEGY, 0, 1)
         self.template = ReferencedObject(self, SBOL_TEMPLATE, 1, 1,
                                          initial_value=template)
@@ -25,10 +25,10 @@ class CombinatorialDerivation(TopLevel):
                 raise ValidationError(f'{self.strategy} is not a valid strategy')
 
 
-def build_combinatorial_derivation(name: str,
+def build_combinatorial_derivation(identity: str,
                                    *, type_uri: str = SBOL_COMBINATORIAL_DERIVATION):
     template = PYSBOL3_MISSING
-    return CombinatorialDerivation(name, template, type_uri=type_uri)
+    return CombinatorialDerivation(identity, template, type_uri=type_uri)
 
 
 Document.register_builder(SBOL_COMBINATORIAL_DERIVATION, build_combinatorial_derivation)

--- a/sbol3/component.py
+++ b/sbol3/component.py
@@ -6,17 +6,9 @@ from . import *
 
 class Component(TopLevel):
 
-    @staticmethod
-    def build_component(name: str, *, type_uri: str = SBOL_COMPONENT) -> SBOLObject:
-        missing = PYSBOL3_MISSING
-        obj = Component(name, [missing], type_uri=type_uri)
-        # Remove the dummy values
-        obj._properties[SBOL_TYPE] = []
-        return obj
-
-    def __init__(self, name: str, component_type: Union[List[str], str],
+    def __init__(self, identity: str, component_type: Union[List[str], str],
                  *, type_uri: str = SBOL_COMPONENT):
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         if isinstance(component_type, str):
             component_type = [component_type]
         self.types: Union[List, Property] = URIProperty(self, SBOL_TYPE, 1, math.inf,
@@ -45,9 +37,9 @@ class Component(TopLevel):
         self._validate_types()
 
 
-def build_component(name: str, *, type_uri: str = SBOL_COMPONENT) -> SBOLObject:
+def build_component(identity: str, *, type_uri: str = SBOL_COMPONENT) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = Component(name, [missing], type_uri=type_uri)
+    obj = Component(identity, [missing], type_uri=type_uri)
     # Remove the dummy values
     obj._properties[SBOL_TYPE] = []
     return obj

--- a/sbol3/compref.py
+++ b/sbol3/compref.py
@@ -9,9 +9,9 @@ class ComponentReference(Feature):
 
     def __init__(self, in_child_of: Union[SubComponent, str],
                  feature: Union[Feature, str],
-                 *, name: str = None,
+                 *, identity: str = None,
                  type_uri: str = SBOL_COMPONENT_REFERENCE) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         self.in_child_of = ReferencedObject(self, SBOL_IN_CHILD_OF, 1, 1,
                                             initial_value=in_child_of)
         self.feature = ReferencedObject(self, SBOL_FEATURES, 1, 1,
@@ -29,10 +29,10 @@ class ComponentReference(Feature):
             raise ValidationError(msg)
 
 
-def build_component_reference(name: str, *,
+def build_component_reference(identity: str, *,
                               type_uri: str = SBOL_COMPONENT_REFERENCE) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = ComponentReference(missing, missing, name=name, type_uri=type_uri)
+    obj = ComponentReference(missing, missing, identity=identity, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[SBOL_FEATURES] = []
     obj._properties[SBOL_IN_CHILD_OF] = []

--- a/sbol3/constraint.py
+++ b/sbol3/constraint.py
@@ -6,9 +6,9 @@ from . import *
 class Constraint(Identified):
 
     def __init__(self, restriction: str, subject: Union[Identified, str],
-                 object: Union[Identified, str], *, name: Optional[str] = None,
+                 object: Union[Identified, str], *, identity: Optional[str] = None,
                  type_uri: str = SBOL_CONSTRAINT) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         self.restriction = URIProperty(self, SBOL_RESTRICTION, 1, 1,
                                        initial_value=restriction)
         self.subject = ReferencedObject(self, SBOL_SUBJECT, 1, 1,
@@ -27,9 +27,9 @@ class Constraint(Identified):
             raise ValidationError('Constraint must have an object')
 
 
-def build_constraint(name: str, type_uri: str = SBOL_CONSTRAINT) -> SBOLObject:
+def build_constraint(identity: str, type_uri: str = SBOL_CONSTRAINT) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = Constraint(missing, missing, missing, name=name, type_uri=type_uri)
+    obj = Constraint(missing, missing, missing, identity=identity, type_uri=type_uri)
     obj._properties[SBOL_RESTRICTION] = []
     obj._properties[SBOL_SUBJECT] = []
     obj._properties[SBOL_OBJECT] = []

--- a/sbol3/custom.py
+++ b/sbol3/custom.py
@@ -5,9 +5,9 @@ from . import *
 
 class CustomIdentified(Identified):
 
-    def __init__(self, type_uri: str = None, *, name: str = None,
+    def __init__(self, type_uri: str = None, *, identity: str = None,
                  sbol_type_uri: str = SBOL_IDENTIFIED) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         self.rdf_type = URIProperty(self, rdflib.RDF.type, 1, 1,
                                     initial_value=sbol_type_uri)
 
@@ -19,9 +19,9 @@ class CustomIdentified(Identified):
 
 class CustomTopLevel(TopLevel):
 
-    def __init__(self, name: str = None, type_uri: str = None,
+    def __init__(self, identity: str = None, type_uri: str = None,
                  *, sbol_type_uri: str = SBOL_TOP_LEVEL) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         self.rdf_type = URIProperty(self, rdflib.RDF.type, 1, 1,
                                     initial_value=sbol_type_uri)
 

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -55,7 +55,7 @@ class Document:
             except KeyError:
                 logging.warning(f'No builder found for {other_type}')
                 builder = CustomIdentified
-            return builder(name=identity, type_uri=other_type)
+            return builder(identity=identity, type_uri=other_type)
         elif SBOL_TOP_LEVEL in types:
             types.remove(SBOL_TOP_LEVEL)
             try:
@@ -69,7 +69,7 @@ class Document:
             except KeyError:
                 logging.warning(f'No builder found for {other_type}')
                 builder = CustomTopLevel
-            return builder(name=identity, type_uri=other_type)
+            return builder(identity=identity, type_uri=other_type)
         else:
             message = 'Custom types must contain either Identified or TopLevel'
             raise ValidationError(message)
@@ -97,7 +97,7 @@ class Document:
                 except KeyError:
                     logging.warning(f'No builder found for {type_uri}')
                     raise ValidationError(f'Unknown type {type_uri}')
-                obj = builder(name=identity, type_uri=type_uri)
+                obj = builder(identity=identity, type_uri=type_uri)
             elif len(types) == 2:
                 obj = self._make_custom_object(identity, types)
             else:

--- a/sbol3/expdata.py
+++ b/sbol3/expdata.py
@@ -3,8 +3,8 @@ from . import *
 
 class ExperimentalData(TopLevel):
 
-    def __init__(self, name: str, *, type_uri: str = SBOL_EXPERIMENTAL_DATA):
-        super().__init__(name, type_uri)
+    def __init__(self, identity: str, *, type_uri: str = SBOL_EXPERIMENTAL_DATA):
+        super().__init__(identity, type_uri)
 
 
 Document.register_builder(SBOL_EXPERIMENTAL_DATA, ExperimentalData)

--- a/sbol3/extdef.py
+++ b/sbol3/extdef.py
@@ -14,9 +14,9 @@ class ExternallyDefined(Feature):
     """
 
     def __init__(self, types: List[str], definition: str,
-                 *, name: str = None,
+                 *, identity: str = None,
                  type_uri: str = SBOL_EXTERNALLY_DEFINED):
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         self.types: uri_list = URIProperty(self, SBOL_TYPE, 1, math.inf,
                                            initial_value=types)
         self.definition: uri_singleton = URIProperty(self, SBOL_DEFINITION, 1, 1,
@@ -31,10 +31,10 @@ class ExternallyDefined(Feature):
             raise ValidationError('ExternallyDefined must have a definition')
 
 
-def build_externally_defined(name: str,
+def build_externally_defined(identity: str,
                              *, type_uri: str = SBOL_EXTERNALLY_DEFINED) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = ExternallyDefined([missing], missing, name=name, type_uri=type_uri)
+    obj = ExternallyDefined([missing], missing, identity=identity, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[SBOL_TYPE] = []
     obj._properties[SBOL_DEFINITION] = []

--- a/sbol3/feature.py
+++ b/sbol3/feature.py
@@ -7,8 +7,8 @@ from . import *
 class Feature(Identified, abc.ABC):
     """Feature is an abstract base class."""
 
-    def __init__(self, name: str, type_uri: str) -> None:
-        super().__init__(name, type_uri)
+    def __init__(self, identity: str, type_uri: str) -> None:
+        super().__init__(identity, type_uri)
         self.roles = URIProperty(self, SBOL_ROLE, 0, math.inf)
         self.orientation = URIProperty(self, SBOL_ORIENTATION, 0, 1)
 

--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -10,8 +10,8 @@ from . import *
 
 class Identified(SBOLObject):
 
-    def __init__(self, name: str, type_uri: str) -> None:
-        super().__init__(name, type_uri)
+    def __init__(self, identity: str, type_uri: str) -> None:
+        super().__init__(identity, type_uri)
         self._display_id = TextProperty(self, SBOL_DISPLAY_ID, 0, 1)
         self.name = TextProperty(self, SBOL_NAME, 0, 1)
         self.description = TextProperty(self, SBOL_DESCRIPTION, 0, 1)

--- a/sbol3/implementation.py
+++ b/sbol3/implementation.py
@@ -3,8 +3,8 @@ from . import *
 
 class Implementation(TopLevel):
 
-    def __init__(self, name: str, *, type_uri: str = SBOL_IMPLEMENTATION) -> None:
-        super().__init__(name, type_uri)
+    def __init__(self, identity: str, *, type_uri: str = SBOL_IMPLEMENTATION) -> None:
+        super().__init__(identity, type_uri)
         self.built = ReferencedObject(self, SBOL_BUILT, 0, 1)
         self.validate()
 

--- a/sbol3/interaction.py
+++ b/sbol3/interaction.py
@@ -7,9 +7,9 @@ from . import *
 class Interaction(Identified):
 
     def __init__(self, interaction_types: List[str],
-                 *, name: str = None,
+                 *, identity: str = None,
                  type_uri: str = SBOL_INTERACTION) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         self.types = URIProperty(self, SBOL_TYPE, 1, math.inf,
                                  initial_value=interaction_types)
         self.participations = OwnedObject(self, SBOL_PARTICIPATIONS, 0, math.inf,
@@ -19,9 +19,9 @@ class Interaction(Identified):
         super().validate()
 
 
-def build_interaction(name: str, *, type_uri: str = SBOL_INTERACTION) -> SBOLObject:
+def build_interaction(identity: str, *, type_uri: str = SBOL_INTERACTION) -> SBOLObject:
     interaction_type = PYSBOL3_MISSING
-    obj = Interaction([interaction_type], name=name, type_uri=type_uri)
+    obj = Interaction([interaction_type], identity=identity, type_uri=type_uri)
     # Remove the dummy type
     obj._properties[SBOL_TYPE] = []
     return obj

--- a/sbol3/interface.py
+++ b/sbol3/interface.py
@@ -5,9 +5,9 @@ from . import *
 
 class Interface(Identified):
 
-    def __init__(self, *, name: str = None,
+    def __init__(self, *, identity: str = None,
                  type_uri: str = SBOL_INTERFACE) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         self.input = ReferencedObject(self, SBOL_INPUT, 0, math.inf)
         self.output = ReferencedObject(self, SBOL_OUTPUT, 0, math.inf)
         self.non_directional = ReferencedObject(self, SBOL_NON_DIRECTIONAL, 0, math.inf)
@@ -17,8 +17,8 @@ class Interface(Identified):
         super().validate()
 
 
-def build_interface(name: str, *, type_uri: str = SBOL_INTERFACE) -> SBOLObject:
-    return Interface(name=name, type_uri=type_uri)
+def build_interface(identity: str, *, type_uri: str = SBOL_INTERFACE) -> SBOLObject:
+    return Interface(identity=identity, type_uri=type_uri)
 
 
 Document.register_builder(SBOL_INTERFACE, build_interface)

--- a/sbol3/localsub.py
+++ b/sbol3/localsub.py
@@ -9,9 +9,9 @@ from .typing import *
 class LocalSubComponent(Feature):
 
     def __init__(self, types: List[str],
-                 *, name: str = None,
+                 *, identity: str = None,
                  type_uri: str = SBOL_LOCAL_SUBCOMPONENT) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         self.types: uri_list = URIProperty(self, SBOL_TYPE, 1, math.inf,
                                            initial_value=types)
         self.locations = OwnedObject(self, SBOL_LOCATION, 0, math.inf,
@@ -24,10 +24,10 @@ class LocalSubComponent(Feature):
             raise ValidationError('LocalSubComponent must have at least 1 type')
 
 
-def build_local_subcomponent(name: str,
+def build_local_subcomponent(identity: str,
                              *, type_uri: str = SBOL_LOCAL_SUBCOMPONENT) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = LocalSubComponent([missing], name=name, type_uri=type_uri)
+    obj = LocalSubComponent([missing], identity=identity, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[SBOL_TYPE] = []
     return obj

--- a/sbol3/location.py
+++ b/sbol3/location.py
@@ -9,8 +9,8 @@ int_property = Union[IntProperty, int]
 class Location(Identified, abc.ABC):
 
     def __init__(self, seq_or_uri: Union[Sequence, str],
-                 name: str, type_uri: str) -> None:
-        super().__init__(name, type_uri)
+                 identity: str, type_uri: str) -> None:
+        super().__init__(identity, type_uri)
         self.orientation = URIProperty(self, SBOL_ORIENTATION, 0, 1)
         self.order = IntProperty(self, SBOL_ORDER, 0, 1)
         self.sequence = ReferencedObject(self, SBOL_SEQUENCES, 1, 1,
@@ -25,8 +25,8 @@ class Location(Identified, abc.ABC):
 class Range(Location):
 
     def __init__(self, seq_or_uri: Union[Sequence, str], start: int, end: int,
-                 *, name: str = None, type_uri: str = SBOL_RANGE) -> None:
-        super().__init__(seq_or_uri, name, type_uri)
+                 *, identity: str = None, type_uri: str = SBOL_RANGE) -> None:
+        super().__init__(seq_or_uri, identity, type_uri)
         self.start: int_property = IntProperty(self, SBOL_START, 1, 1,
                                                initial_value=start)
         self.end: int_property = IntProperty(self, SBOL_END, 1, 1,
@@ -43,12 +43,12 @@ class Range(Location):
             raise ValidationError('End must be >= start')
 
 
-def build_range(name: str, type_uri: str = SBOL_RANGE):
+def build_range(identity: str, type_uri: str = SBOL_RANGE):
     """Used by Document to construct a Range when reading an SBOL file.
     """
     start = 1
     end = 1
-    obj = Range(PYSBOL3_MISSING, start, end, name=name, type_uri=type_uri)
+    obj = Range(PYSBOL3_MISSING, start, end, identity=identity, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[SBOL_SEQUENCES] = []
     obj._properties[SBOL_START] = []
@@ -62,8 +62,8 @@ Document.register_builder(SBOL_RANGE, build_range)
 class Cut(Location):
 
     def __init__(self, seq_or_uri: Union[Sequence, str], at: int,
-                 *, name: str = None, type_uri: str = SBOL_CUT) -> None:
-        super().__init__(seq_or_uri, name, type_uri)
+                 *, identity: str = None, type_uri: str = SBOL_CUT) -> None:
+        super().__init__(seq_or_uri, identity, type_uri)
         self.at: int_property = IntProperty(self, SBOL_START, 1, 1,
                                             initial_value=at)
         self.validate()
@@ -74,11 +74,11 @@ class Cut(Location):
             raise ValidationError('At must be >= 0')
 
 
-def build_cut(name: str, type_uri: str = SBOL_CUT):
+def build_cut(identity: str, type_uri: str = SBOL_CUT):
     """Used by Document to construct a Cut when reading an SBOL file.
     """
     at = 0
-    obj = Cut(PYSBOL3_MISSING, at, name=name, type_uri=type_uri)
+    obj = Cut(PYSBOL3_MISSING, at, identity=identity, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[SBOL_SEQUENCES] = []
     obj._properties[SBOL_START] = []
@@ -91,16 +91,16 @@ Document.register_builder(SBOL_CUT, build_cut)
 class EntireSequence(Location):
 
     def __init__(self, seq_or_uri: Union[Sequence, str],
-                 *, name: str = None,
+                 *, identity: str = None,
                  type_uri: str = SBOL_ENTIRE_SEQUENCE) -> None:
-        super().__init__(seq_or_uri, name, type_uri)
+        super().__init__(seq_or_uri, identity, type_uri)
         self.validate()
 
 
-def build_entire_sequence(name: str, type_uri: str = SBOL_ENTIRE_SEQUENCE):
+def build_entire_sequence(identity: str, type_uri: str = SBOL_ENTIRE_SEQUENCE):
     """Used by Document to construct an EntireSequence when reading an SBOL file.
     """
-    obj = EntireSequence(PYSBOL3_MISSING, name=name, type_uri=type_uri)
+    obj = EntireSequence(PYSBOL3_MISSING, identity=identity, type_uri=type_uri)
     obj._properties[SBOL_SEQUENCES] = []
     return obj
 

--- a/sbol3/model.py
+++ b/sbol3/model.py
@@ -3,8 +3,8 @@ from . import *
 
 class Model(TopLevel):
 
-    def __init__(self, name: str, *, type_uri: str = SBOL_MODEL) -> None:
-        super().__init__(name, type_uri)
+    def __init__(self, identity: str, *, type_uri: str = SBOL_MODEL) -> None:
+        super().__init__(identity, type_uri)
         self.source = URIProperty(self, SBOL_SOURCE, 1, 1)
         self.language = URIProperty(self, SBOL_LANGUAGE, 1, 1)
         self.framework = URIProperty(self, SBOL_FRAMEWORK, 1, 1)

--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -113,7 +113,8 @@ class SBOLObject:
                 old_uri = self.identity
                 new_uri = replace_namespace(old_uri, target_namespace, self.getTypeURI())
 
-        new_obj = BUILDER_REGISTER[self.type_uri](name=new_uri, type_uri=self.type_uri)
+        new_obj = BUILDER_REGISTER[self.type_uri](identity=new_uri,
+                                                  type_uri=self.type_uri)
 
         # Copy properties
         for property_uri, value_store in self._properties.items():

--- a/sbol3/om_compound.py
+++ b/sbol3/om_compound.py
@@ -8,17 +8,17 @@ from .om_unit import Unit
 
 class CompoundUnit(Unit, abc.ABC):
 
-    def __init__(self, name: str, symbol: str, label: str,
+    def __init__(self, identity: str, symbol: str, label: str,
                  type_uri: str) -> None:
-        super().__init__(name, symbol, label, type_uri)
+        super().__init__(identity, symbol, label, type_uri)
 
 
 class UnitMultiplication(CompoundUnit):
 
-    def __init__(self, name: str, symbol: str, label: str,
+    def __init__(self, identity: str, symbol: str, label: str,
                  term1: Union[Unit, str], term2: Union[Unit, str],
                  *, type_uri: str = OM_UNIT_MULTIPLICATION) -> None:
-        super().__init__(name, symbol, label, type_uri)
+        super().__init__(identity, symbol, label, type_uri)
         self.term1 = ReferencedObject(self, OM_HAS_TERM1, 1, 1,
                                       initial_value=term1)
         self.term2 = ReferencedObject(self, OM_HAS_TERM2, 1, 1,
@@ -26,10 +26,11 @@ class UnitMultiplication(CompoundUnit):
         self.validate()
 
 
-def build_unit_multiplication(name: str,
+def build_unit_multiplication(identity: str,
                               *, type_uri: str = OM_UNIT_MULTIPLICATION) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = UnitMultiplication(name, missing, missing, missing, missing, type_uri=type_uri)
+    obj = UnitMultiplication(identity, missing, missing, missing, missing,
+                             type_uri=type_uri)
     # Remove the dummy values
     obj._properties[OM_SYMBOL] = []
     obj._properties[OM_LABEL] = []
@@ -43,10 +44,10 @@ Document.register_builder(OM_UNIT_MULTIPLICATION, build_unit_multiplication)
 
 class UnitDivision(CompoundUnit):
 
-    def __init__(self, name: str, symbol: str, label: str,
+    def __init__(self, identity: str, symbol: str, label: str,
                  numerator: Union[Unit, str], denominator: Union[Unit, str],
                  *, type_uri: str = OM_UNIT_DIVISION) -> None:
-        super().__init__(name, symbol, label, type_uri)
+        super().__init__(identity, symbol, label, type_uri)
         self.numerator = ReferencedObject(self, OM_HAS_NUMERATOR, 1, 1,
                                           initial_value=numerator)
         self.denominator = ReferencedObject(self, OM_HAS_DENOMINATOR, 1, 1,
@@ -54,9 +55,10 @@ class UnitDivision(CompoundUnit):
         self.validate()
 
 
-def build_unit_division(name: str, *, type_uri: str = OM_UNIT_DIVISION) -> SBOLObject:
+def build_unit_division(identity: str,
+                        *, type_uri: str = OM_UNIT_DIVISION) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = UnitDivision(name, missing, missing, missing, missing, type_uri=type_uri)
+    obj = UnitDivision(identity, missing, missing, missing, missing, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[OM_SYMBOL] = []
     obj._properties[OM_LABEL] = []
@@ -70,10 +72,10 @@ Document.register_builder(OM_UNIT_DIVISION, build_unit_division)
 
 class UnitExponentiation(CompoundUnit):
 
-    def __init__(self, name: str, symbol: str, label: str,
+    def __init__(self, identity: str, symbol: str, label: str,
                  base: Union[Unit, str], exponent: int,
                  *, type_uri: str = OM_UNIT_EXPONENTIATION) -> None:
-        super().__init__(name, symbol, label, type_uri)
+        super().__init__(identity, symbol, label, type_uri)
         self.base = ReferencedObject(self, OM_HAS_BASE, 1, 1,
                                      initial_value=base)
         self.exponent = IntProperty(self, OM_HAS_EXPONENT, 1, 1,
@@ -81,10 +83,10 @@ class UnitExponentiation(CompoundUnit):
         self.validate()
 
 
-def build_unit_exponentiation(name: str,
+def build_unit_exponentiation(identity: str,
                               *, type_uri: str = OM_UNIT_EXPONENTIATION) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = UnitExponentiation(name, missing, missing, missing, 1, type_uri=type_uri)
+    obj = UnitExponentiation(identity, missing, missing, missing, 1, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[OM_SYMBOL] = []
     obj._properties[OM_LABEL] = []

--- a/sbol3/om_prefix.py
+++ b/sbol3/om_prefix.py
@@ -10,9 +10,9 @@ class Prefix(CustomTopLevel, abc.ABC):
     See Appendix A Section A.2 of the SBOL 3.0 specificiation.
     """
 
-    def __init__(self, name: str, symbol: str, label: str,
+    def __init__(self, identity: str, symbol: str, label: str,
                  factor: float, type_uri: str) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         self.symbol = TextProperty(self, OM_SYMBOL, 1, 1,
                                    initial_value=symbol)
         self.alternative_symbols = TextProperty(self, OM_ALTERNATIVE_SYMBOL,
@@ -38,15 +38,15 @@ class Prefix(CustomTopLevel, abc.ABC):
 
 class SIPrefix(Prefix):
 
-    def __init__(self, name: str, symbol: str, label: str,
+    def __init__(self, identity: str, symbol: str, label: str,
                  factor: float, *, type_uri: str = OM_SI_PREFIX) -> None:
-        super().__init__(name, symbol, label, factor, type_uri)
+        super().__init__(identity, symbol, label, factor, type_uri)
         self.validate()
 
 
-def build_si_prefix(name: str, *, type_uri: str = OM_SI_PREFIX) -> SBOLObject:
+def build_si_prefix(identity: str, *, type_uri: str = OM_SI_PREFIX) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = SIPrefix(name, missing, missing, 1.0, type_uri=type_uri)
+    obj = SIPrefix(identity, missing, missing, 1.0, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[OM_SYMBOL] = []
     obj._properties[OM_LABEL] = []
@@ -59,15 +59,16 @@ Document.register_builder(OM_SI_PREFIX, build_si_prefix)
 
 class BinaryPrefix(Prefix):
 
-    def __init__(self, name: str, symbol: str, label: str,
+    def __init__(self, identity: str, symbol: str, label: str,
                  factor: float, *, type_uri: str = OM_BINARY_PREFIX) -> None:
-        super().__init__(name, symbol, label, factor, type_uri)
+        super().__init__(identity, symbol, label, factor, type_uri)
         self.validate()
 
 
-def build_binary_prefix(name: str, *, type_uri: str = OM_BINARY_PREFIX) -> SBOLObject:
+def build_binary_prefix(identity: str,
+                        *, type_uri: str = OM_BINARY_PREFIX) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = BinaryPrefix(name, missing, missing, 1.0, type_uri=type_uri)
+    obj = BinaryPrefix(identity, missing, missing, 1.0, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[OM_SYMBOL] = []
     obj._properties[OM_LABEL] = []

--- a/sbol3/om_unit.py
+++ b/sbol3/om_unit.py
@@ -12,9 +12,9 @@ class Unit(CustomTopLevel, abc.ABC):
     See Appendix A Section A.2 of the SBOL 3.0 specificiation.
     """
 
-    def __init__(self, name: str, symbol: str, label: str,
+    def __init__(self, identity: str, symbol: str, label: str,
                  type_uri: str) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         self.symbol = TextProperty(self, OM_SYMBOL, 1, 1,
                                    initial_value=symbol)
         self.alternative_symbols = TextProperty(self, OM_ALTERNATIVE_SYMBOL,
@@ -30,9 +30,9 @@ class Unit(CustomTopLevel, abc.ABC):
 class Measure(CustomIdentified):
 
     def __init__(self, value: float, unit: str,
-                 *, name: str = None,
+                 *, identity: str = None,
                  type_uri: str = OM_MEASURE) -> None:
-        super().__init__(name=name, type_uri=type_uri)
+        super().__init__(identity=identity, type_uri=type_uri)
         self.value = FloatProperty(self, OM_HAS_NUMERICAL_VALUE, 1, 1,
                                    initial_value=value)
         self.types = URIProperty(self, SBOL_TYPE, 0, math.inf)
@@ -41,9 +41,9 @@ class Measure(CustomIdentified):
         self.validate()
 
 
-def build_measure(name: str, *, type_uri: str = OM_MEASURE) -> SBOLObject:
+def build_measure(identity: str, *, type_uri: str = OM_MEASURE) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = Measure(1.0, missing, name=name, type_uri=type_uri)
+    obj = Measure(1.0, missing, identity=identity, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[OM_HAS_NUMERICAL_VALUE] = []
     obj._properties[OM_HAS_UNIT] = []
@@ -55,17 +55,18 @@ Document.register_builder(OM_MEASURE, build_measure)
 
 class SingularUnit(Unit):
 
-    def __init__(self, name: str, symbol: str, label: str,
+    def __init__(self, identity: str, symbol: str, label: str,
                  *, type_uri: str = OM_SINGULAR_UNIT) -> None:
-        super().__init__(name, symbol, label, type_uri)
+        super().__init__(identity, symbol, label, type_uri)
         self.unit = ReferencedObject(self, OM_HAS_UNIT, 0, 1)
         self.factor = FloatProperty(self, OM_HAS_FACTOR, 0, 1)
         self.validate()
 
 
-def build_singular_unit(name: str, *, type_uri: str = OM_SINGULAR_UNIT) -> SBOLObject:
+def build_singular_unit(identity: str,
+                        *, type_uri: str = OM_SINGULAR_UNIT) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = SingularUnit(name, missing, missing, type_uri=type_uri)
+    obj = SingularUnit(identity, missing, missing, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[OM_SYMBOL] = []
     obj._properties[OM_LABEL] = []
@@ -77,11 +78,11 @@ Document.register_builder(OM_SINGULAR_UNIT, build_singular_unit)
 
 class PrefixedUnit(Unit):
 
-    def __init__(self, name: str, symbol: str, label: str,
+    def __init__(self, identity: str, symbol: str, label: str,
                  unit: Union[Unit, str],
                  prefix: Union[Prefix, str],
                  *, type_uri: str = OM_PREFIXED_UNIT) -> None:
-        super().__init__(name, symbol, label, type_uri)
+        super().__init__(identity, symbol, label, type_uri)
         self.unit = ReferencedObject(self, OM_HAS_UNIT, 1, 1,
                                      initial_value=unit)
         self.prefix = ReferencedObject(self, OM_HAS_PREFIX, 1, 1,
@@ -89,9 +90,10 @@ class PrefixedUnit(Unit):
         self.validate()
 
 
-def build_prefixed_unit(name: str, *, type_uri: str = OM_PREFIXED_UNIT) -> SBOLObject:
+def build_prefixed_unit(identity: str,
+                        *, type_uri: str = OM_PREFIXED_UNIT) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = PrefixedUnit(name, missing, missing, missing, missing, type_uri=type_uri)
+    obj = PrefixedUnit(identity, missing, missing, missing, missing, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[OM_SYMBOL] = []
     obj._properties[OM_LABEL] = []

--- a/sbol3/participation.py
+++ b/sbol3/participation.py
@@ -8,9 +8,9 @@ class Participation(Identified):
 
     def __init__(self, roles: List[str],
                  participant: Union[SBOLObject, str],
-                 *, name: str = None,
+                 *, identity: str = None,
                  type_uri: str = SBOL_PARTCIPATION) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         self.roles: uri_list = URIProperty(self, SBOL_ROLE, 1, math.inf,
                                            initial_value=roles)
         self.participant = ReferencedObject(self, SBOL_PARTICIPANT, 1, 1,
@@ -25,9 +25,10 @@ class Participation(Identified):
             raise ValidationError('Participation must have a participant')
 
 
-def build_participation(name: str, *, type_uri: str = SBOL_PARTCIPATION) -> SBOLObject:
+def build_participation(identity: str,
+                        *, type_uri: str = SBOL_PARTCIPATION) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = Participation([missing], missing, name=name, type_uri=type_uri)
+    obj = Participation([missing], missing, identity=identity, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[SBOL_ROLE] = []
     obj._properties[SBOL_PARTICIPANT] = []

--- a/sbol3/provenance.py
+++ b/sbol3/provenance.py
@@ -6,18 +6,18 @@ from . import *
 
 class Usage(CustomIdentified):
 
-    def __init__(self, entity: str, *, name: str = None,
+    def __init__(self, entity: str, *, identity: str = None,
                  type_uri: str = PROV_USAGE) -> None:
-        super().__init__(name=name, type_uri=type_uri)
+        super().__init__(identity=identity, type_uri=type_uri)
         self.entity = URIProperty(self, PROV_ENTITY, 1, 1,
                                   initial_value=entity)
         self.roles = URIProperty(self, PROV_ROLES, 0, math.inf)
         self.validate()
 
 
-def build_usage(name: str, *, type_uri: str = PROV_USAGE) -> SBOLObject:
+def build_usage(identity: str, *, type_uri: str = PROV_USAGE) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = Usage(missing, name=name, type_uri=type_uri)
+    obj = Usage(missing, identity=identity, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[PROV_ENTITY] = []
     return obj
@@ -28,8 +28,8 @@ Document.register_builder(PROV_USAGE, build_usage)
 
 class Agent(CustomTopLevel):
 
-    def __init__(self, name: str, *, type_uri: str = PROV_AGENT) -> None:
-        super().__init__(name, type_uri)
+    def __init__(self, identity: str, *, type_uri: str = PROV_AGENT) -> None:
+        super().__init__(identity, type_uri)
         self.validate()
 
 
@@ -38,8 +38,8 @@ Document.register_builder(PROV_AGENT, Agent)
 
 class Plan(CustomTopLevel):
 
-    def __init__(self, name: str, *, type_uri: str = PROV_PLAN) -> None:
-        super().__init__(name, type_uri)
+    def __init__(self, identity: str, *, type_uri: str = PROV_PLAN) -> None:
+        super().__init__(identity, type_uri)
         self.validate()
 
 
@@ -49,9 +49,9 @@ Document.register_builder(PROV_PLAN, Plan)
 class Association(CustomIdentified):
 
     def __init__(self, agent: Union[str, Identified],
-                 *, name: str = None,
+                 *, identity: str = None,
                  type_uri: str = PROV_ASSOCIATION) -> None:
-        super().__init__(name=name, type_uri=type_uri)
+        super().__init__(identity=identity, type_uri=type_uri)
         self.roles = URIProperty(self, PROV_ROLES, 0, math.inf)
         self.plan = ReferencedObject(self, PROV_PLANS, 0, 1)
         self.agent = ReferencedObject(self, PROV_AGENTS, 1, 1,
@@ -59,9 +59,9 @@ class Association(CustomIdentified):
         self.validate()
 
 
-def build_association(name: str, *, type_uri: str = PROV_USAGE) -> SBOLObject:
+def build_association(identity: str, *, type_uri: str = PROV_USAGE) -> SBOLObject:
     missing = PYSBOL3_MISSING
-    obj = Association(missing, name=name, type_uri=type_uri)
+    obj = Association(missing, identity=identity, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[PROV_AGENTS] = []
     return obj
@@ -72,8 +72,8 @@ Document.register_builder(PROV_ASSOCIATION, build_association)
 
 class Activity(CustomTopLevel):
 
-    def __init__(self, name: str, *, type_uri: str = PROV_ACTIVITY) -> None:
-        super().__init__(name, type_uri)
+    def __init__(self, identity: str, *, type_uri: str = PROV_ACTIVITY) -> None:
+        super().__init__(identity, type_uri)
         self.types = URIProperty(self, SBOL_TYPE, 0, math.inf)
         self.start_time = DateTimeProperty(self, PROV_STARTED_AT_TIME, 0, 1)
         self.end_time = DateTimeProperty(self, PROV_ENDED_AT_TIME, 0, 1)

--- a/sbol3/seqfeat.py
+++ b/sbol3/seqfeat.py
@@ -10,9 +10,9 @@ from .typing import *
 class SequenceFeature(Feature):
 
     def __init__(self, locations: List[Location],
-                 *, name: str = None,
+                 *, identity: str = None,
                  type_uri: str = SBOL_SEQUENCE_FEATURE) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         self.locations: oo_list = OwnedObject(self, SBOL_LOCATION,
                                               1, math.inf,
                                               type_constraint=Location,
@@ -25,9 +25,9 @@ class SequenceFeature(Feature):
             raise ValidationError('LocalSubComponent must have at least 1 location')
 
 
-def build_sequence_feature(name: str,
+def build_sequence_feature(identity: str,
                            *, type_uri: str = SBOL_SEQUENCE_FEATURE) -> SBOLObject:
-    obj = SequenceFeature([EntireSequence()], name=name, type_uri=type_uri)
+    obj = SequenceFeature([EntireSequence()], identity=identity, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[SBOL_LOCATION] = []
     return obj

--- a/sbol3/sequence.py
+++ b/sbol3/sequence.py
@@ -3,8 +3,8 @@ from . import *
 
 class Sequence(TopLevel):
 
-    def __init__(self, name: str, *, type_uri: str = SBOL_SEQUENCE) -> None:
-        super().__init__(name, type_uri)
+    def __init__(self, identity: str, *, type_uri: str = SBOL_SEQUENCE) -> None:
+        super().__init__(identity, type_uri)
         self.elements = TextProperty(self, SBOL_ELEMENTS, 0, 1)
         self.encoding = URIProperty(self, SBOL_ENCODING, 0, 1)
         self.validate()

--- a/sbol3/subcomponent.py
+++ b/sbol3/subcomponent.py
@@ -9,8 +9,8 @@ from .feature import Feature
 class SubComponent(Feature):
 
     def __init__(self, instance_of: Union[Identified, str],
-                 *, name: str = None, type_uri: str = SBOL_SUBCOMPONENT) -> None:
-        super().__init__(name, type_uri)
+                 *, identity: str = None, type_uri: str = SBOL_SUBCOMPONENT) -> None:
+        super().__init__(identity, type_uri)
         self.role_integration = URIProperty(self, SBOL_ROLE, 0, 1)
         self.instance_of = ReferencedObject(self, SBOL_INSTANCE_OF, 1, 1,
                                             initial_value=instance_of)
@@ -27,11 +27,11 @@ class SubComponent(Feature):
             raise ValidationError('SubComponent must have an instance_of')
 
 
-def build_subcomponent(name: str, type_uri: str = SBOL_SUBCOMPONENT) -> Identified:
+def build_subcomponent(identity: str, type_uri: str = SBOL_SUBCOMPONENT) -> Identified:
     """Used by Document to construct a SubComponent when reading an SBOL file.
     """
     missing = PYSBOL3_MISSING
-    obj = SubComponent(missing, name=name, type_uri=type_uri)
+    obj = SubComponent(missing, identity=identity, type_uri=type_uri)
     obj._properties[SBOL_INSTANCE_OF] = []
     return obj
 

--- a/sbol3/toplevel.py
+++ b/sbol3/toplevel.py
@@ -5,8 +5,8 @@ from . import *
 
 class TopLevel(Identified):
 
-    def __init__(self, name: str, type_uri: str) -> None:
-        super().__init__(name, type_uri)
+    def __init__(self, identity: str, type_uri: str) -> None:
+        super().__init__(identity, type_uri)
         self.attachments = ReferencedObject(self, SBOL_HAS_ATTACHMENT, 0, math.inf)
 
     def validate_identity(self) -> None:

--- a/sbol3/varcomp.py
+++ b/sbol3/varcomp.py
@@ -8,9 +8,9 @@ class VariableComponent(Identified):
     def __init__(self, *,
                  cardinality: str = None,
                  variable: str = None,
-                 name: str = None,
+                 identity: str = None,
                  type_uri: str = SBOL_VARIABLE_COMPONENT) -> None:
-        super().__init__(name, type_uri)
+        super().__init__(identity, type_uri)
         # Assign default values
         if cardinality is None:
             cardinality = SBOL_ZERO_OR_MORE

--- a/test/test_custom.py
+++ b/test/test_custom.py
@@ -16,8 +16,8 @@ PYSBOL3_CUSTOM_INT = 'https://github.com/synbiodex/pysbol3#customInt'
 
 
 class CustomTopClass(sbol3.CustomTopLevel):
-    def __init__(self, name, type_uri=PYSBOL3_CUSTOM_TOP):
-        super().__init__(name, type_uri)
+    def __init__(self, identity, type_uri=PYSBOL3_CUSTOM_TOP):
+        super().__init__(identity, type_uri)
         # Also test the boolean list while we're here
         self.foo_bool = sbol3.BooleanProperty(self, PYSBOL3_CUSTOM_BOOL,
                                               0, math.inf)
@@ -25,8 +25,8 @@ class CustomTopClass(sbol3.CustomTopLevel):
 
 
 class CustomIdentifiedClass(sbol3.CustomIdentified):
-    def __init__(self, type_uri=PYSBOL3_CUSTOM_IDENTIFIED, name=None):
-        super().__init__(type_uri, name=name)
+    def __init__(self, type_uri=PYSBOL3_CUSTOM_IDENTIFIED, identity=None):
+        super().__init__(type_uri, identity=identity)
         # Also test the int list while we're here
         self.foo_int = sbol3.IntProperty(self, PYSBOL3_CUSTOM_INT,
                                          0, math.inf)
@@ -98,7 +98,7 @@ class TestCustomIdentified(unittest.TestCase):
 
     def test_create(self):
         custom_type = 'https://github.com/synbiodex/pysbol3/CustomType'
-        ctl = sbol3.CustomIdentified(name='custom1',
+        ctl = sbol3.CustomIdentified(identity='custom1',
                                      type_uri=custom_type)
         self.assertEqual(custom_type, ctl.type_uri)
         # Go behind the scenes to verify

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -76,9 +76,9 @@ class TestDocument(unittest.TestCase):
         # Ensure that duplicate identities cannot be added to the document.
         # See https://github.com/SynBioDex/pySBOL3/issues/39
         document = sbol3.Document()
-        namespace1 = sbol3.Namespace(name=sbol3.SBOL3_NS)
+        namespace1 = sbol3.Namespace(identity=sbol3.SBOL3_NS)
         document.add(namespace1)
-        namespace2 = sbol3.Namespace(name=sbol3.SBOL3_NS)
+        namespace2 = sbol3.Namespace(identity=sbol3.SBOL3_NS)
         with self.assertRaises(ValueError):
             document.add(namespace2)
 

--- a/test/test_ownedobject.py
+++ b/test/test_ownedobject.py
@@ -11,7 +11,7 @@ class TestOwnedObject(unittest.TestCase):
         con1 = sbol3.Constraint(sbol3.SBOL_REPLACES,
                                 'http://example.com/fake1',
                                 'http://example.com/fake2',
-                                name=con1_id)
+                                identity=con1_id)
         expected = posixpath.join(sbol3.get_namespace(), con1_id)
         # The constraint's identity and display_id will be overwritten as
         # part of the append operation. SBOL Compliant URIs (identities)
@@ -31,7 +31,7 @@ class TestOwnedObject(unittest.TestCase):
         con1 = sbol3.Constraint(sbol3.SBOL_REPLACES,
                                 'http://example.com/fake1',
                                 'http://example.com/fake2',
-                                name=con1_id)
+                                identity=con1_id)
         expected = posixpath.join(sbol3.get_namespace(), con1_id)
         expected2 = posixpath.join(comp.identity, 'Constraint1')
         self.assertNotEqual(expected, expected2)

--- a/test/test_referenced_object.py
+++ b/test/test_referenced_object.py
@@ -12,8 +12,8 @@ class SingleRefObj(sbol3.TopLevel):
     SRO_URI = 'https://github.com/synbiodex/sbol3#SingleRefObj'
     SEQUENCE_URI = 'https://github.com/synbiodex/sbol3#sequence'
 
-    def __init__(self, name: str, type_uri: str = SRO_URI):
-        super().__init__(name, type_uri)
+    def __init__(self, identity: str, type_uri: str = SRO_URI):
+        super().__init__(identity, type_uri)
         self.sequence = sbol3.ReferencedObject(self, SingleRefObj.SEQUENCE_URI, 0, 1)
 
 


### PR DESCRIPTION
The use of "name" as the argument caused confusion. The argument does not populate the "name" field of an object. Rather, it is used to populate the identity and/or display_id. Switch to calling it identity, which is the first use in the heuristic. If the value is not a valid identity it is assumed to be a display_id and concatenated with a default namespace if one exists.

@bbartley @tramyn this pull request contains a change that is _not_ backward compatible. It is very likely that some of your code will have to change. You will need to change any registered builders (via `Document.register_builder`) to rename the `name` argument to `identity`.

Additionally if you have code that invokes a constructor using a `name` keyword argument, that invocation must be updated by renaming `name` to `identity`.

CC: @jakebeal 

Closes #130 