### PR TITLE
Add a unit test/example

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -225,7 +225,7 @@ class Document:
                 return obj
         return self._find_in_objects(search_string)
 
-    def write_string(self, file_format: str) -> bytes:
+    def write_string(self, file_format: str) -> str:
         graph = self.graph()
         if file_format == SORTED_NTRIPLES:
             # have RDFlib give us the ntriples as a string

--- a/test/test_subcomponent.py
+++ b/test/test_subcomponent.py
@@ -18,6 +18,27 @@ class TestSubComponent(unittest.TestCase):
         with self.assertRaises(sbol3.ValidationError):
             sbol3.SubComponent('')
 
+    def test_external_instance_of(self):
+        # See https://github.com/SynBioDex/pySBOL3/issues/136
+        c_uri = 'https://synbiohub.example.org/component1'
+        m9_media = 'https://synbiohub.example.org/m9-media'
+        e_coli = 'https://synbiohub.example.org/e-coli-DH5-alpha'
+        c = sbol3.Component(c_uri, sbol3.SBO_DNA)
+        sc1 = sbol3.SubComponent(m9_media)
+        sc2 = sbol3.SubComponent(e_coli)
+        c.features = [sc1, sc2]
+        self.assertEqual(len(c.features), 2)
+        doc1 = sbol3.Document()
+        doc1.add(c)
+        doc2 = sbol3.Document()
+        doc2.read_string(doc1.write_string(sbol3.NTRIPLES),
+                         sbol3.NTRIPLES)
+        c2 = doc2.find(c_uri)
+        self.assertIsNotNone(c2)
+        self.assertEqual(2, len(c2.features))
+        self.assertCountEqual([m9_media, e_coli],
+                              [sc.instance_of for sc in c2.features])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add a unit test showing the use of external references via a SubComponent.
This example came up in an issue, so encode the example to ensure
proper functionality now and in the future.

See #136 