### PR TITLE
Remove default namespace

### DIFF
--- a/sbol3/config.py
+++ b/sbol3/config.py
@@ -1,29 +1,33 @@
 import warnings
+from typing import Optional
 from urllib.parse import urlparse
 
 # We probably want to turn this into a dict like the configuration dict
 # in pySBOL2. When we have more variables to store, let's change this
 # to a dict.
-SBOL3_NAMESPACE = ''
+SBOL3_NAMESPACE = None
 
 
-def get_namespace() -> str:
+def get_namespace() -> Optional[str]:
     return SBOL3_NAMESPACE
 
 
-def set_namespace(namespace: str) -> None:
+def set_namespace(namespace: Optional[str]) -> None:
+    global SBOL3_NAMESPACE
+    if namespace is None:
+        SBOL3_NAMESPACE = None
+        return
     parsed = urlparse(namespace)
     if parsed.scheme and parsed.netloc:
-        global SBOL3_NAMESPACE
         SBOL3_NAMESPACE = namespace
     else:
-        raise ValueError(f'Expected URL found {namespace}')
+        raise ValueError(f'Expected URL, found {namespace}')
 
 
 def set_defaults() -> None:
     """Restores configuration to factory settings.
     """
-    set_namespace('http://example.com/sbol3/')
+    set_namespace(None)
 
 
 set_defaults()

--- a/sbol3/error.py
+++ b/sbol3/error.py
@@ -8,3 +8,14 @@ class ValidationError(Error):
 
     def __init__(self, message: str):
         self.message = message
+
+
+class NamespaceError(Error):
+    """Exception raised for namespace errors.
+
+    Attributes:
+        message -- explanation of the error
+    """
+
+    def __init__(self, message: str):
+        self.message = message

--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -74,8 +74,8 @@ class SBOLObject:
         base_uri = get_namespace()
         if base_uri is None:
             msg = 'No default namespace available.'
-            msg += ' Use set_namespace to set one.'
-            raise ValueError(msg)
+            msg += ' Use set_namespace() to set one.'
+            raise NamespaceError(msg)
         if base_uri.endswith('#'):
             return base_uri + name
         else:

--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -72,6 +72,10 @@ class SBOLObject:
             pass
         # Not a URL or a UUID, so append to the namespace
         base_uri = get_namespace()
+        if base_uri is None:
+            msg = 'No default namespace available.'
+            msg += ' Use set_namespace to set one.'
+            raise ValueError(msg)
         if base_uri.endswith('#'):
             return base_uri + name
         else:

--- a/test/test_annotation.py
+++ b/test/test_annotation.py
@@ -7,11 +7,17 @@ import sbol3
 
 class TestAnnotation(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_annotation(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         # Create custom annotation
         annotation_uri = 'http://example.org/boolean_property'
         annotation_value = 'foo'
-
         c = sbol3.Component('c1', sbol3.SBO_DNA)
         c.annotation = sbol3.TextProperty(c, annotation_uri,
                                           0, 1, [])

--- a/test/test_attachment.py
+++ b/test/test_attachment.py
@@ -9,7 +9,14 @@ SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 
 class TestAttachment(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         base_url = 'https://github.com/SynBioDex/pySBOL3/'
         source_uri = base_url + 'blob/master/sbol3/attachment.py'
         att = sbol3.Attachment('attachment1', source_uri)

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -7,7 +7,14 @@ import sbol3
 
 class TestCollection(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         collection = sbol3.Collection('collection1')
         self.assertIsNotNone(collection)
         self.assertEqual(0, len(collection.members))
@@ -22,6 +29,7 @@ class TestCollection(unittest.TestCase):
         self.assertIsInstance(collection, sbol3.Collection)
 
     def test_member_property(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         self.assertTrue(hasattr(sbol3, 'SBOL_MEMBER'))
         collection = sbol3.Collection('collection1')
         self.assertIn(sbol3.SBOL_MEMBER, collection._properties)
@@ -36,7 +44,14 @@ class TestCollection(unittest.TestCase):
 
 class TestNamespace(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         namespace = sbol3.Namespace('namespace1')
         self.assertIsNotNone(namespace)
         self.assertEqual(0, len(namespace.members))
@@ -53,7 +68,14 @@ class TestNamespace(unittest.TestCase):
 
 class TestExperiment(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         experiment = sbol3.Experiment('experiment1')
         self.assertIsNotNone(experiment)
         self.assertEqual(0, len(experiment.members))

--- a/test/test_combderiv.py
+++ b/test/test_combderiv.py
@@ -5,7 +5,14 @@ import sbol3
 
 class TestCombinatorialDerivation(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         template = 'https://github.com/synbiodex/pysbol3/component'
         cd1 = sbol3.CombinatorialDerivation('cd1', template)
         self.assertEqual(template, cd1.template)
@@ -14,6 +21,7 @@ class TestCombinatorialDerivation(unittest.TestCase):
         self.assertEqual(comp1.identity, cd2.template)
 
     def test_invalid_strategy(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         # Test with invalid strategy
         comp1 = sbol3.Component('comp1', sbol3.SBO_DNA)
         cd1 = sbol3.CombinatorialDerivation('cd1', comp1)

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -26,6 +26,24 @@ class TestComponent(unittest.TestCase):
         self.assertEqual([sbol3.SO_PROMOTER, sbol3.SO_RBS], c.roles)
         self.assertEqual([sbol3.SO_RBS], c.roles[1:])
 
+    def test_features(self):
+        # See https://github.com/SynBioDex/pySBOL3/issues/149
+        media_template = sbol3.LocalSubComponent(identity='https://sd2e.org/media_template',
+                                                 types=[sbol3.SBO_FUNCTIONAL_ENTITY])
+        media_template.name = 'media template'
+
+        media_variable = sbol3.VariableFeature(cardinality=sbol3.SBOL_ONE)
+        media_variable.variable = media_template
+
+        all_sample_templates = [media_template]
+        sample_template = sbol3.Component(identity='https://sd2e.org/measurement_template',
+                                          component_type=sbol3.SBO_FUNCTIONAL_ENTITY)
+        sample_template.name = 'measurement template'
+        sample_template.features = all_sample_templates
+        self.assertEqual(1, len(sample_template.features))
+        self.assertEqual(media_template.identity,
+                         sample_template.features[0].identity)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -6,7 +6,14 @@ import sbol3
 
 class TestComponent(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_roles(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         c = sbol3.Component('c1', sbol3.SBO_DNA)
         self.assertListEqual([], list(c.roles))
         self.assertEqual([], c.roles)

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -28,7 +28,9 @@ class TestComponent(unittest.TestCase):
 
     def test_features(self):
         # See https://github.com/SynBioDex/pySBOL3/issues/149
-        media_template = sbol3.LocalSubComponent(identity='https://sd2e.org/media_template',
+
+        media_template_uri = 'https://sd2e.org/media_template'
+        media_template = sbol3.LocalSubComponent(identity=media_template_uri,
                                                  types=[sbol3.SBO_FUNCTIONAL_ENTITY])
         media_template.name = 'media template'
 
@@ -36,7 +38,8 @@ class TestComponent(unittest.TestCase):
         media_variable.variable = media_template
 
         all_sample_templates = [media_template]
-        sample_template = sbol3.Component(identity='https://sd2e.org/measurement_template',
+        sample_template_uri = 'https://sd2e.org/measurement_template'
+        sample_template = sbol3.Component(identity=sample_template_uri,
                                           component_type=sbol3.SBO_FUNCTIONAL_ENTITY)
         sample_template.name = 'measurement template'
         sample_template.features = all_sample_templates

--- a/test/test_compref.py
+++ b/test/test_compref.py
@@ -9,6 +9,12 @@ SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 
 class TestComponentReference(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
         in_child_of = 'https://github.com/synbiodex/pysbol3/subcomponent'
         feature = 'https://github.com/synbiodex/pysbol3/other_feature'

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -11,6 +11,9 @@ class TestConfig(unittest.TestCase):
     def setUp(self) -> None:
         sbol3.set_defaults()
 
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_namespace(self):
         base_uri = 'https://github.com/synbiodex/pysbol3'
         sbol3.set_namespace(base_uri)
@@ -21,6 +24,14 @@ class TestConfig(unittest.TestCase):
         base_uri = 'https://synbiohub.org'
         sbol3.set_namespace(base_uri)
         self.assertEqual(base_uri, sbol3.get_namespace())
+
+    def test_no_namespace(self):
+        # Make sure there is no default namespace
+        self.assertEqual(None, sbol3.get_namespace())
+        # Make sure that creating an object with a display_id
+        # and no default namespace raises an exception
+        with self.assertRaises(ValueError):
+            c = sbol3.Component('c1', sbol3.SBO_DNA)
 
 
 if __name__ == '__main__':

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -30,7 +30,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(None, sbol3.get_namespace())
         # Make sure that creating an object with a display_id
         # and no default namespace raises an exception
-        with self.assertRaises(ValueError):
+        with self.assertRaises(sbol3.NamespaceError):
             c = sbol3.Component('c1', sbol3.SBO_DNA)
 
 

--- a/test/test_custom.py
+++ b/test/test_custom.py
@@ -46,7 +46,14 @@ class TestCustomTopLevel(unittest.TestCase):
         if PYSBOL3_CUSTOM_TOP in store:
             del store[PYSBOL3_CUSTOM_TOP]
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         custom_type = 'https://github.com/synbiodex/pysbol3/CustomType'
         ctl = sbol3.CustomTopLevel('custom1', custom_type)
         self.assertEqual(custom_type, ctl.type_uri)
@@ -60,6 +67,7 @@ class TestCustomTopLevel(unittest.TestCase):
     def test_round_trip(self):
         # Test the boolean list property, which is not used by the
         # core SBOL 3 data model
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         obj_name = 'bool_test'
         obj = CustomTopClass(obj_name)
         self.assertEqual([], obj.foo_bool)
@@ -107,7 +115,14 @@ class TestCustomIdentified(unittest.TestCase):
             if uri in store:
                 del store[uri]
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         custom_type = 'https://github.com/synbiodex/pysbol3/CustomType'
         ctl = sbol3.CustomIdentified(identity='custom1',
                                      type_uri=custom_type)
@@ -123,6 +138,7 @@ class TestCustomIdentified(unittest.TestCase):
     def test_round_trip(self):
         # Test the int list property, which is not used by the
         # core SBOL 3 data model
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         obj = CustomIdentifiedClass()
         self.assertEqual([], obj.foo_int)
         obj.foo_int.append(7)

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -17,6 +17,12 @@ class TestDocument(unittest.TestCase):
     def setUpClass(cls) -> None:
         logging.basicConfig(level=logging.INFO)
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_read_ntriples(self):
         # Initial test of Document.read
         filename = 'model.nt'
@@ -62,6 +68,7 @@ class TestDocument(unittest.TestCase):
         doc.read(test_path, sbol3.TURTLE)
 
     def test_add(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         doc = sbol3.Document()
         type_uri = 'https://github.com/synbiodex/sbol3#TestObj'
         obj1 = sbol3.SBOLObject('obj', type_uri)
@@ -83,6 +90,7 @@ class TestDocument(unittest.TestCase):
             document.add(namespace2)
 
     def test_write(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         doc = sbol3.Document()
         doc.add(sbol3.Component('c1', sbol3.SBO_DNA))
         with tempfile.TemporaryDirectory() as tmpdirname:
@@ -129,6 +137,7 @@ class TestDocument(unittest.TestCase):
         self.assertEqual(0, len(g))
 
     def test_graph(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         doc = sbol3.Document()
         doc.add(sbol3.Component('foo', sbol3.SBO_DNA))
         graph = doc.graph()

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -19,6 +19,7 @@ EXPECTED_CIRCUIT = os.path.join(TEST_DIR, 'resources', 'circuit.nt')
 class TestExamples(unittest.TestCase):
 
     def setUp(self):
+        sbol3.set_defaults()
         # Create temp directory
         self.temp_out_dir = tempfile.mkdtemp()
         self.logger = logging.getLogger('sbol3.test')
@@ -30,6 +31,7 @@ class TestExamples(unittest.TestCase):
         if self.temp_out_dir:
             shutil.rmtree(self.temp_out_dir)
             self.temp_out_dir = None
+        sbol3.set_defaults()
 
     def test_circuit_example(self):
         cmd = [sys.executable, CIRCUIT_EXAMPLE]

--- a/test/test_expdata.py
+++ b/test/test_expdata.py
@@ -9,7 +9,14 @@ class TestExperimentalData(unittest.TestCase):
     # here. There are not yet any examples in the SBOLTestSuite. And
     # the class doesn't have any properties of its own.
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         display_id = 'exp_data'
         exp_data = sbol3.ExperimentalData(display_id)
         self.assertIsNotNone(exp_data)

--- a/test/test_extdef.py
+++ b/test/test_extdef.py
@@ -9,6 +9,12 @@ SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 
 class TestExternallyDefined(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
         types = ['https://identifiers.org/SBO:0000247']
         definition = 'https://identifiers.org/CHEBI:3312'

--- a/test/test_identified.py
+++ b/test/test_identified.py
@@ -12,7 +12,11 @@ class TestIdentified(unittest.TestCase):
     def setUp(self) -> None:
         sbol3.set_defaults()
 
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_display_id(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         c1_display_id = 'c1'
         c = sbol3.Component(c1_display_id, sbol3.SBO_DNA)
         self.assertEqual(c1_display_id, c.display_id)
@@ -31,6 +35,7 @@ class TestIdentified(unittest.TestCase):
         # Test setting of display_id
         #   * Test by passing display_id to constructor
         #   * Test by having display_id deduced from identity
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         c1_display_id = 'c1'
         c1_identity = posixpath.join(sbol3.get_namespace(), c1_display_id)
         c1 = sbol3.Component(c1_display_id, sbol3.SBO_DNA)
@@ -47,12 +52,14 @@ class TestIdentified(unittest.TestCase):
         # Verify that a UUID can be used as an identity and that
         # the object does not have a display_id since the identity
         # is not a URL
-        identity = str(uuid.uuid5(uuid.NAMESPACE_URL, sbol3.get_namespace()))
+        identity = str(uuid.uuid5(uuid.NAMESPACE_URL,
+                                  'https://github.com/synbiodex/pysbol3'))
         c = sbol3.Component(identity, sbol3.SBO_DNA)
         self.assertEqual(identity, c.identity)
         self.assertIsNone(c.display_id)
 
     def test_basic_serialization(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         c = sbol3.Component('c1', sbol3.SBO_DNA)
         graph = rdflib.Graph()
         c.serialize(graph)

--- a/test/test_implementation.py
+++ b/test/test_implementation.py
@@ -9,7 +9,14 @@ SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 
 class TestImplementation(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         implementation = sbol3.Implementation('impl1')
         self.assertIsNotNone(implementation)
         self.assertIsNone(implementation.built)

--- a/test/test_interaction.py
+++ b/test/test_interaction.py
@@ -7,6 +7,12 @@ import sbol3
 
 class TestInteraction(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
         types = [sbol3.SBO_INHIBITION]
         interaction = sbol3.Interaction(types)

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -9,6 +9,12 @@ SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 
 class TestInterface(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
         interface = sbol3.Interface()
         self.assertIsNotNone(interface)

--- a/test/test_localsub.py
+++ b/test/test_localsub.py
@@ -5,6 +5,12 @@ import sbol3
 
 class TestLocalSubComponent(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
         types = [sbol3.SBO_DNA]
         lsc = sbol3.LocalSubComponent(types)

--- a/test/test_location.py
+++ b/test/test_location.py
@@ -5,6 +5,12 @@ import sbol3
 
 class TestRange(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_creation(self):
         start = 1
         end = 10
@@ -36,6 +42,12 @@ class TestRange(unittest.TestCase):
 
 class TestCut(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_creation(self):
         at = 1
         cut = sbol3.Cut(sbol3.PYSBOL3_MISSING, at)
@@ -54,6 +66,12 @@ class TestCut(unittest.TestCase):
 
 
 class TestEntireSequence(unittest.TestCase):
+
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
 
     def test_creation(self):
         # EntireSequence has no properties, so there isn't much to test here

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -9,6 +9,9 @@ class TestObject(unittest.TestCase):
     def setUp(self) -> None:
         sbol3.set_defaults()
 
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_trailing_slash(self):
         # A trailing slash on an object's identity should automatically be removed
         sbol3.set_namespace('http://example.org/sbol3')
@@ -19,13 +22,14 @@ class TestObject(unittest.TestCase):
         self.assertEqual(identity, c.identity)
 
     def test_copy_properties(self):
-        doc = sbol3.Document()
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         root = sbol3.Component('root', sbol3.SBO_DNA)
         root.name = 'foo'
         root_copy = root.copy()
         self.assertEqual(root_copy.name, 'foo')
 
     def test_copy_child_objects(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         doc = sbol3.Document()
         root = sbol3.Component('root', sbol3.SBO_DNA)
         sub1 = sbol3.Component('sub1', sbol3.SBO_DNA)

--- a/test/test_om_compound.py
+++ b/test/test_om_compound.py
@@ -9,7 +9,14 @@ SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 
 class TestUnitDivision(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         # Note, in practice we would use the already defined
         # http://www.ontology-of-units-of-measure.org/resource/om-2/kilometrePerHour
         display_id = 'udivision'
@@ -42,7 +49,14 @@ class TestUnitDivision(unittest.TestCase):
 
 class TestUnitExponentiation(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         # Note, in practice we would use the already defined
         # http://www.ontology-of-units-of-measure.org/resource/om-2/cubicMetre
         display_id = 'uexponentiation'
@@ -75,7 +89,14 @@ class TestUnitExponentiation(unittest.TestCase):
 
 class TestUnitMultiplication(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         # Note, in practice we would use the already defined
         # http://www.ontology-of-units-of-measure.org/resource/om-2/kelvinMole
         display_id = 'umultiplication'

--- a/test/test_om_prefix.py
+++ b/test/test_om_prefix.py
@@ -9,7 +9,14 @@ SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 
 class TestSIPrefix(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         display_id = 'si_prefix'
         symbol = 'kilo'
         label = 'Kilo'
@@ -42,7 +49,14 @@ class TestSIPrefix(unittest.TestCase):
 
 class TestBinaryPrefix(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         display_id = 'binary_prefix'
         symbol = 'kilo'
         label = 'Kilo'

--- a/test/test_om_unit.py
+++ b/test/test_om_unit.py
@@ -9,6 +9,12 @@ SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 
 class TestMeasure(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
         unit = 'https://sbolstandard.org/examples/millimolePerLitre'
         value = 0.1
@@ -42,7 +48,14 @@ class TestMeasure(unittest.TestCase):
 
 class TestPrefixedUnit(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         display_id = 'millimole'
         symbol = display_id
         label = display_id
@@ -75,7 +88,14 @@ class TestPrefixedUnit(unittest.TestCase):
 
 class TestSingularUnit(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         display_id = 'litre'
         symbol = display_id
         label = display_id

--- a/test/test_ownedobject.py
+++ b/test/test_ownedobject.py
@@ -5,7 +5,14 @@ import sbol3
 
 class TestOwnedObject(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_identity_append(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         comp = sbol3.Component('c1', sbol3.SBO_DNA)
         con1_id = 'con1'
         con1 = sbol3.Constraint(sbol3.SBOL_REPLACES,
@@ -26,6 +33,7 @@ class TestOwnedObject(unittest.TestCase):
 
     def test_list_property_update_identity(self):
         # This test uses assignment instead of appending
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         comp = sbol3.Component('c1', sbol3.SBO_DNA)
         con1_id = 'con1'
         con1 = sbol3.Constraint(sbol3.SBOL_REPLACES,
@@ -41,6 +49,7 @@ class TestOwnedObject(unittest.TestCase):
         self.assertEqual(expected2, con1.identity)
 
     def test_singleton_property_update_identity(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         tl = sbol3.CustomTopLevel('foo', 'http://synbio.bbn.com/opil#MeasurementValue')
         tl.measure = sbol3.OwnedObject(tl, 'http://synbio.bbn.com/opil#measure', 0, 1)
         m = sbol3.Measure(10, 'liters')
@@ -52,6 +61,7 @@ class TestOwnedObject(unittest.TestCase):
     def test_add_multiple_children(self):
         # Test that the the display_id and identity are overwritten
         # properly when adding multiple child entities.
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         comp = sbol3.Component('c1', sbol3.SBO_DNA)
         comp.constraints.append(sbol3.Constraint(sbol3.SBOL_REPLACES,
                                                  'http://example.com/fake1',
@@ -67,8 +77,8 @@ class TestOwnedObject(unittest.TestCase):
     def test_identity_conflict2(self):
         # Test that the same display id will cause a validation
         # error when an item with the same display id is appended
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         comp = sbol3.Component('c1', sbol3.SBO_DNA)
-        con1_id = 'con1'
         constraints = [sbol3.Constraint(sbol3.SBOL_REPLACES,
                                         'http://example.com/fake1',
                                         'http://example.com/fake2'),
@@ -84,6 +94,7 @@ class TestOwnedObject(unittest.TestCase):
     def test_cascade_identity(self):
         # Test that updating identity of an owned object cascades
         # to child owned objects
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         c1 = sbol3.Component('c1', sbol3.SBO_DNA)
         seq = sbol3.Sequence('seq1')
         loc = sbol3.EntireSequence(seq)
@@ -95,6 +106,7 @@ class TestOwnedObject(unittest.TestCase):
         self.assertIsNotNone(loc.identity)
 
     def test_type_constraint(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         c = sbol3.Component('foo', sbol3.SBO_DNA)
         with self.assertRaises(TypeError):
             c.features = [sbol3.Range('https://example.com/fake', 1, 2)]

--- a/test/test_participation.py
+++ b/test/test_participation.py
@@ -9,6 +9,12 @@ SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
 
 class TestParticipation(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
         participant = 'https://github.com/synbiodex/pysbol3/participant1'
         p = sbol3.Participation([sbol3.SBO_INHIBITOR], participant)

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -8,7 +8,14 @@ import sbol3
 
 class TestProperty(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_slice_assignment(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         c = sbol3.Component('c1', sbol3.SBO_DNA)
         self.assertEqual([], c.roles)
         c.roles.append(sbol3.SO_PROMOTER)
@@ -41,6 +48,7 @@ class TestProperty(unittest.TestCase):
         self.assertEqual(expected, c._properties[sbol3.SBOL_ROLE])
 
     def test_boolean_property(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         c = sbol3.Component('c1', sbol3.SBO_DNA)
         c.boolean_attribute = sbol3.BooleanProperty(c, 'http://example.org#foo',
                                                     0, 1, [])
@@ -48,6 +56,7 @@ class TestProperty(unittest.TestCase):
         self.assertEqual(type(c.boolean_attribute), bool)
 
     def test_bounds(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         c = sbol3.Component('c1', sbol3.SBO_DNA)
         c.boolean_attribute = sbol3.BooleanProperty(c, 'http://example.org#foo',
                                                     0, math.inf, [])

--- a/test/test_provenance.py
+++ b/test/test_provenance.py
@@ -5,7 +5,14 @@ import sbol3
 
 class TestActivity(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         display_id = 'activity'
         activity = sbol3.Activity(display_id)
         self.assertIsNotNone(activity)
@@ -21,7 +28,14 @@ class TestActivity(unittest.TestCase):
 
 class TestAgent(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         display_id = 'agent'
         agent = sbol3.Agent(display_id)
         self.assertIsNotNone(agent)
@@ -32,7 +46,14 @@ class TestAgent(unittest.TestCase):
 
 class TestAssociation(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         agent = sbol3.Agent('agent')
         association = sbol3.Association(agent)
         self.assertIsNotNone(association)
@@ -43,7 +64,14 @@ class TestAssociation(unittest.TestCase):
 
 class TestPlan(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         display_id = 'plan'
         plan = sbol3.Plan(display_id)
         self.assertIsNotNone(plan)
@@ -54,7 +82,14 @@ class TestPlan(unittest.TestCase):
 
 class TestUsage(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         agent = sbol3.Agent('agent')
         usage = sbol3.Usage(agent.identity)
         self.assertIsNotNone(usage)

--- a/test/test_referenced_object.py
+++ b/test/test_referenced_object.py
@@ -22,6 +22,9 @@ class TestReferencedObject(unittest.TestCase):
     def setUp(self) -> None:
         sbol3.set_defaults()
 
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_lookup(self):
         test_path = os.path.join(SBOL3_LOCATION, 'entity', 'model', 'model.ttl')
         test_format = sbol3.TURTLE
@@ -39,6 +42,7 @@ class TestReferencedObject(unittest.TestCase):
 
     def test_uri_assignment(self):
         # Test assignment to a ReferencedObject attribute with a URI string
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         doc = sbol3.Document()
         component = sbol3.Component('c1', sbol3.SBO_DNA)
         sequence = sbol3.Sequence('seq1')
@@ -54,6 +58,7 @@ class TestReferencedObject(unittest.TestCase):
     def test_instance_append(self):
         # Test assignment to a ReferencedObject attribute with an
         # instance using append
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         doc = sbol3.Document()
         component = sbol3.Component('c1', sbol3.SBO_DNA)
         sequence = sbol3.Sequence('seq1')
@@ -68,6 +73,7 @@ class TestReferencedObject(unittest.TestCase):
     def test_instance_assignment(self):
         # Test assignment to a ReferencedObject attribute with an
         # instance using assignment
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         doc = sbol3.Document()
         component = sbol3.Component('c1', sbol3.SBO_DNA)
         sequence = sbol3.Sequence('seq1')
@@ -82,6 +88,7 @@ class TestReferencedObject(unittest.TestCase):
     def test_singleton_assignment(self):
         # Test assignment to a ReferencedObject attribute with an
         # instance using assignment
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         doc = sbol3.Document()
         test_parent = SingleRefObj('sro1')
         sequence = sbol3.Sequence('seq1')

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -19,6 +19,7 @@ DEBUG_ENV_VAR = 'SBOL_TEST_DEBUG'
 class TestRoundTrip(unittest.TestCase):
 
     def setUp(self):
+        sbol3.set_defaults()
         # Create temp directory
         self.temp_out_dir = tempfile.mkdtemp()
         self.logger = logging.getLogger('sbol3.test')
@@ -32,6 +33,7 @@ class TestRoundTrip(unittest.TestCase):
         if self.temp_out_dir:
             shutil.rmtree(self.temp_out_dir)
             self.temp_out_dir = None
+        sbol3.set_defaults()
 
     def test_BBa_F2620_PoPSReceiver(self):
         sbol_path = os.path.join(SBOL3_LOCATION, 'BBa_F2620_PoPSReceiver',

--- a/test/test_seqfeat.py
+++ b/test/test_seqfeat.py
@@ -5,6 +5,12 @@ import sbol3
 
 class TestSequenceFeature(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
         es1 = sbol3.EntireSequence(sbol3.PYSBOL3_MISSING)
         locations = [es1]

--- a/test/test_sequence.py
+++ b/test/test_sequence.py
@@ -5,7 +5,14 @@ import sbol3
 
 class TestSequence(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         display_id = 'seq1'
         seq = sbol3.Sequence(display_id)
         self.assertIsNotNone(seq)
@@ -14,6 +21,7 @@ class TestSequence(unittest.TestCase):
         self.assertIsNone(seq.encoding)
 
     def test_invalid(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         display_id = 'seq1'
         seq = sbol3.Sequence(display_id)
         self.assertIsNotNone(seq)
@@ -22,6 +30,7 @@ class TestSequence(unittest.TestCase):
             seq.validate()
 
     def test_valid(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         display_id = 'seq1'
         seq = sbol3.Sequence(display_id)
         self.assertIsNotNone(seq)

--- a/test/test_subcomponent.py
+++ b/test/test_subcomponent.py
@@ -5,7 +5,14 @@ import sbol3
 
 class TestSubComponent(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         instance_of = sbol3.Component('comp1', sbol3.SBO_DNA)
         sc1 = sbol3.SubComponent(instance_of)
         self.assertIsNotNone(sc1)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -7,7 +7,14 @@ from sbol3.utils import parse_class_name
 
 class TestUtils(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_parse_class_name(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         # Test parsing with # delimiter in type URI
         c = sbol3.Component('c', sbol3.SBO_DNA)
         class_name = parse_class_name(c.type_uri)

--- a/test/test_varcomp.py
+++ b/test/test_varcomp.py
@@ -5,6 +5,12 @@ import sbol3
 
 class TestVariableComponent(unittest.TestCase):
 
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
     def test_create(self):
         vc = sbol3.VariableFeature()
         self.assertIsNotNone(vc)


### PR DESCRIPTION
**Note: this is a breaking change to the APIs**

* No default namespace - Require programs to set a default namespace or always use fully qualified identities when creating objects. This is a large change, and may break compatibility with existing programs.
* Add NamespaceError - Use custom exception NamespaceError when display_id is passed to constructor and no default namespace is set.
* Closes #99

Previous code that will now break:

```python
c = sbol3.Component('c1', sbol3.SBO_DNA)
```

How to do it now:

```python
c = sbol3.Component('https://github.com/synbiodex/pysbol3/c1',
                    sbol3.SBO_DNA)

OR

sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
c = sbol3.Component('c1', sbol3.SBO_DNA)
```
