### PR TITLE
Rename to variable_components to variable_features

### DIFF
--- a/sbol3/combderiv.py
+++ b/sbol3/combderiv.py
@@ -12,9 +12,9 @@ class CombinatorialDerivation(TopLevel):
         self.strategy = URIProperty(self, SBOL_STRATEGY, 0, 1)
         self.template = ReferencedObject(self, SBOL_TEMPLATE, 1, 1,
                                          initial_value=template)
-        self.variable_components = OwnedObject(self, SBOL_VARIABLE_FEATURES,
-                                               0, math.inf,
-                                               type_constraint=VariableFeature)
+        self.variable_features = OwnedObject(self, SBOL_VARIABLE_FEATURES,
+                                             0, math.inf,
+                                             type_constraint=VariableFeature)
         self.validate()
 
     def validate(self) -> None:


### PR DESCRIPTION
Rename CombinatorialDerivation.variable_components to
CombinatorialDerivation.variable_features to align with
the specification. This was missed in the initial pull
request. This may be a breaking change for some programs.

Fixes #148 