### PR TITLE
Mark replace_namespace as not yet implemented

### DIFF
--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -158,6 +158,11 @@ def replace_namespace(old_uri, target_namespace, rdf_type):
     rdf_type is used to map to and from sbol-typed namespaces.
     """
 
+    # Flag as not working to ensure nobody calls this function thinking
+    # it might do something.
+    # See https://github.com/SynBioDex/pySBOL3/issues/132
+    raise NotImplementedError()
+
     # Work around an issue where the Document itself is being copied and
     # doesn't have its own URI, so old_uri is None. Return empty string
     # because the identity is not allowed to be None.

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -47,6 +47,15 @@ class TestObject(unittest.TestCase):
         self.assertEqual([sc.identity for sc in root.features],
                          [sc.identity for sc in root_copy.features])
 
+    def test_replace_namespace(self):
+        # Verify that replace_namespace is not exported from sbol3
+        self.assertNotIn('replace_namespace', dir(sbol3))
+        # replace_namespace should raise NotImplmentedError
+        # See https://github.com/SynBioDex/pySBOL3/issues/132
+        with self.assertRaises(NotImplementedError):
+            from sbol3.object import replace_namespace
+            replace_namespace(None, None, None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
replace_namespace is carried forward from pySBOL2 and needs work in
order to function in pySBOL3. Mark it as not implemented and document
the shortcomings.

Closes #123 