### PR TITLE
Fix the CombinatorialDerivation type URI

### DIFF
--- a/sbol3/combderiv.py
+++ b/sbol3/combderiv.py
@@ -7,7 +7,7 @@ from . import *
 class CombinatorialDerivation(TopLevel):
 
     def __init__(self, identity: str, template: Union[Component, str],
-                 *, type_uri: str = SBOL_MODEL) -> None:
+                 *, type_uri: str = SBOL_COMBINATORIAL_DERIVATION) -> None:
         super().__init__(identity, type_uri)
         self.strategy = URIProperty(self, SBOL_STRATEGY, 0, 1)
         self.template = ReferencedObject(self, SBOL_TEMPLATE, 1, 1,

--- a/test/test_combderiv.py
+++ b/test/test_combderiv.py
@@ -29,6 +29,23 @@ class TestCombinatorialDerivation(unittest.TestCase):
         with self.assertRaises(sbol3.ValidationError):
             cd1.validate()
 
+    def test_round_trip(self):
+        # See https://github.com/SynBioDex/pySBOL3/issues/156
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
+        comp1 = sbol3.Component('comp1', sbol3.SBO_DNA)
+        cd1 = sbol3.CombinatorialDerivation('cd1', comp1)
+        self.assertEqual(comp1.identity, cd1.template)
+        doc1 = sbol3.Document()
+        doc1.add(comp1)
+        doc1.add(cd1)
+        doc2 = sbol3.Document()
+        doc2.read_string(doc1.write_string(sbol3.SORTED_NTRIPLES),
+                         sbol3.SORTED_NTRIPLES)
+        comp2 = doc2.find(comp1.identity)
+        self.assertIsInstance(comp2, sbol3.Component)
+        cd2 = doc2.find(cd1.identity)
+        self.assertIsInstance(cd2, sbol3.CombinatorialDerivation)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix a copy/paste error that caused CombinatorialDerivation to use the
Model type URI.

Fixes #156 