### PR TITLE
Register a builder for VariableFeature

### DIFF
--- a/sbol3/varcomp.py
+++ b/sbol3/varcomp.py
@@ -40,3 +40,6 @@ class VariableFeature(Identified):
             raise ValidationError(f'{self.cardinality} is not a valid cardinality')
         if self.variable is None:
             raise ValidationError('VariableComponent.variable is required')
+
+
+Document.register_builder(SBOL_VARIABLE_FEATURE, VariableFeature)

--- a/test/test_varcomp.py
+++ b/test/test_varcomp.py
@@ -23,6 +23,28 @@ class TestVariableComponent(unittest.TestCase):
         with self.assertRaises(sbol3.ValidationError):
             vc = sbol3.VariableFeature(cardinality=my_cardinality)
 
+    def test_round_trip1(self):
+        # See https://github.com/SynBioDex/pySBOL3/issues/155
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
+        doc1 = sbol3.Document()
+        comp1 = sbol3.Component('comp1', sbol3.SBO_DNA)
+        doc1.add(comp1)
+        cd1 = sbol3.CombinatorialDerivation('cd1', comp1)
+        self.assertEqual(comp1.identity, cd1.template)
+        doc1.add(cd1)
+        vf1 = sbol3.VariableFeature()
+        cd1.variable_features.append(vf1)
+        self.assertTrue(vf1.identity.startswith(cd1.identity))
+        doc2 = sbol3.Document()
+        doc2.read_string(doc1.write_string(sbol3.SORTED_NTRIPLES),
+                         sbol3.SORTED_NTRIPLES)
+        comp2 = doc2.find(comp1.identity)
+        self.assertIsInstance(comp2, sbol3.Component)
+        cd2 = doc2.find(cd1.identity)
+        self.assertIsInstance(cd2, sbol3.CombinatorialDerivation)
+        vf2 = doc2.find(vf1.identity)
+        self.assertIsInstance(vf2, sbol3.VariableFeature)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Ensure that there is a builder registered for VariableFeature so that files
containing VariableFeatures can be loaded.

Fixes #155 