### PR TITLE
Rename some VariableFeature properties

### DIFF
--- a/sbol3/varcomp.py
+++ b/sbol3/varcomp.py
@@ -21,13 +21,13 @@ class VariableFeature(Identified):
                                        initial_value=cardinality)
         self.variable = ReferencedObject(self, SBOL_VARIABLE, 1, 1,
                                          initial_value=variable)
-        self.variant = ReferencedObject(self, SBOL_VARIANT, 0, math.inf)
-        self.variant_collection = ReferencedObject(self, SBOL_VARIANT_COLLECTION,
-                                                   0, math.inf)
-        self.variant_derivation = ReferencedObject(self, SBOL_VARIANT_DERIVATION,
-                                                   0, math.inf)
-        self.variant_measure = OwnedObject(self, SBOL_VARIANT_MEASURE,
-                                           0, math.inf)
+        self.variants = ReferencedObject(self, SBOL_VARIANT, 0, math.inf)
+        self.variant_collections = ReferencedObject(self, SBOL_VARIANT_COLLECTION,
+                                                    0, math.inf)
+        self.variant_derivations = ReferencedObject(self, SBOL_VARIANT_DERIVATION,
+                                                    0, math.inf)
+        self.variant_measures = OwnedObject(self, SBOL_VARIANT_MEASURE,
+                                            0, math.inf)
         # Validate
         self.validate()
 

--- a/test/test_varcomp.py
+++ b/test/test_varcomp.py
@@ -57,7 +57,7 @@ class TestVariableComponent(unittest.TestCase):
         vf1 = sbol3.VariableFeature()
         hour = 'https://identifiers.org/ncit:C25529'
         m1 = sbol3.Measure(32, hour)
-        vf1.variant_measure.append(m1)
+        vf1.variant_measures.append(m1)
         cd1.variable_features.append(vf1)
         self.assertTrue(vf1.identity.startswith(cd1.identity))
         # Ensure that Measure m1 is valid. The bug tested here was that it


### PR DESCRIPTION
Give some VariableFeature properties plural names (like "variants")
because they contain multiple values.

Fixes #161 