### PR TITLE
Overhaul validation

### DIFF
--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -1,0 +1,31 @@
+Validation in pySBOL3
+=============================
+
+The pySBOL3 library includes a capability to generate a validation
+report for an SBOL3 object or an SBOL3 Document. The report can be
+used to check your work or fix issues with your document or object.
+
+Here is a short example of how to validate an object. We intentionally
+create a Range with end before start, which is invalid SBOL3. This
+generates a validation error in the ValidationReport:
+
+.. code:: python
+
+    >>> import sbol3
+    RDFLib Version: 5.0.0
+    >>> seq_uri = 'https://github.com/synbiodex/pysbol3/sequence'
+    >>> start = 10
+    >>> end = 1
+    >>> r = sbol3.Range(seq_uri, start, end)
+    >>> report = r.validate()
+    >>> len(report)
+    1
+    >>> for error in report.errors:
+    ...     print(error.message)
+    ...
+    End must be >= start
+
+.. end
+
+Validating an object automatically validates and child objects. Invoking `validate()`
+on a document will validate all objects contained in that document.

--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -23,7 +23,7 @@ generates a validation error in the ValidationReport:
     >>> for error in report.errors:
     ...     print(error.message)
     ...
-    End must be >= start
+    sbol3-11403: Range.end must be >= start
 
 .. end
 

--- a/sbol3/__init__.py
+++ b/sbol3/__init__.py
@@ -5,6 +5,7 @@ from .config import set_defaults, get_namespace, set_namespace
 # get_homespace and set_homespace are deprecated and included for backward compatibility
 from .config import get_homespace, set_homespace
 from .error import *
+from .validation import *
 from .object import SBOLObject
 from .property_base import Property, SingletonProperty, ListProperty
 from .text_property import TextSingletonProperty, TextProperty

--- a/sbol3/attachment.py
+++ b/sbol3/attachment.py
@@ -13,12 +13,13 @@ class Attachment(TopLevel):
         self.hash = TextProperty(self, SBOL_HASH, 0, 1)
         self.hash_algorithm = TextProperty(self, SBOL_HASH_ALGORITHM, 0, 1)
 
-    def validate(self, report: ValidationReport) -> None:
-        super().validate(report)
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         # An Attachment must have 1 source
         if self.source is None:
             message = f'Attachment {self.identity} must have a source'
             report.addError(None, message)
+        return report
 
 
 def build_attachment(identity: str, *, type_uri: str = SBOL_COMPONENT) -> SBOLObject:

--- a/sbol3/attachment.py
+++ b/sbol3/attachment.py
@@ -18,7 +18,7 @@ class Attachment(TopLevel):
         # An Attachment must have 1 source
         if self.source is None:
             message = f'Attachment {self.identity} must have a source'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         return report
 
 

--- a/sbol3/attachment.py
+++ b/sbol3/attachment.py
@@ -12,14 +12,13 @@ class Attachment(TopLevel):
         self.size = IntProperty(self, SBOL_SIZE, 0, 1)
         self.hash = TextProperty(self, SBOL_HASH, 0, 1)
         self.hash_algorithm = TextProperty(self, SBOL_HASH_ALGORITHM, 0, 1)
-        self.validate()
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport) -> None:
+        super().validate(report)
         # An Attachment must have 1 source
         if self.source is None:
             message = f'Attachment {self.identity} must have a source'
-            raise ValidationError(message)
+            report.addError(None, message)
 
 
 def build_attachment(identity: str, *, type_uri: str = SBOL_COMPONENT) -> SBOLObject:

--- a/sbol3/combderiv.py
+++ b/sbol3/combderiv.py
@@ -15,14 +15,15 @@ class CombinatorialDerivation(TopLevel):
         self.variable_features = OwnedObject(self, SBOL_VARIABLE_FEATURES,
                                              0, math.inf,
                                              type_constraint=VariableFeature)
-        self.validate()
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         if self.strategy is not None:
             valid_strategies = [SBOL_ENUMERATE, SBOL_SAMPLE]
             if self.strategy not in valid_strategies:
-                raise ValidationError(f'{self.strategy} is not a valid strategy')
+                message = f'{self.strategy} is not a valid strategy'
+                report.addError(None, message)
+        return report
 
 
 def build_combinatorial_derivation(identity: str,

--- a/sbol3/combderiv.py
+++ b/sbol3/combderiv.py
@@ -22,7 +22,7 @@ class CombinatorialDerivation(TopLevel):
             valid_strategies = [SBOL_ENUMERATE, SBOL_SAMPLE]
             if self.strategy not in valid_strategies:
                 message = f'{self.strategy} is not a valid strategy'
-                report.addError(None, message)
+                report.addError(self.identity, None, message)
         return report
 
 

--- a/sbol3/component.py
+++ b/sbol3/component.py
@@ -29,7 +29,7 @@ class Component(TopLevel):
         # A Component is REQUIRED to have one or more type properties (Section 6.4)
         if len(self.types) < 1:
             message = f'Component {self.identity} has no types'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
 
     def validate(self, report: ValidationReport = None) -> ValidationReport:
         report = super().validate(report)

--- a/sbol3/component.py
+++ b/sbol3/component.py
@@ -31,9 +31,10 @@ class Component(TopLevel):
             message = f'Component {self.identity} has no types'
             report.addError(None, message)
 
-    def validate(self, report: ValidationReport) -> None:
-        super().validate(report)
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         self._validate_types(report)
+        return report
 
 
 def build_component(identity: str, *, type_uri: str = SBOL_COMPONENT) -> SBOLObject:

--- a/sbol3/component.py
+++ b/sbol3/component.py
@@ -24,15 +24,14 @@ class Component(TopLevel):
         self.interfaces = OwnedObject(self, SBOL_INTERFACES, 0, 1,
                                       type_constraint=Interface)
         self.models = ReferencedObject(self, SBOL_MODELS, 0, math.inf)
-        self.validate()
 
-    def _validate_types(self) -> None:
+    def _validate_types(self, report: ValidationReport) -> None:
         # A Component is REQUIRED to have one or more type properties (Section 6.4)
         if len(self.types) < 1:
             message = f'Component {self.identity} has no types'
-            raise ValidationError(message)
+            report.addError(None, message)
 
-    def validate(self) -> None:
+    def validate(self, report: ValidationReport) -> None:
         super().validate()
         self._validate_types()
 

--- a/sbol3/component.py
+++ b/sbol3/component.py
@@ -32,8 +32,8 @@ class Component(TopLevel):
             report.addError(None, message)
 
     def validate(self, report: ValidationReport) -> None:
-        super().validate()
-        self._validate_types()
+        super().validate(report)
+        self._validate_types(report)
 
 
 def build_component(identity: str, *, type_uri: str = SBOL_COMPONENT) -> SBOLObject:

--- a/sbol3/compref.py
+++ b/sbol3/compref.py
@@ -16,7 +16,6 @@ class ComponentReference(Feature):
                                             initial_value=in_child_of)
         self.feature = ReferencedObject(self, SBOL_FEATURES, 1, 1,
                                         initial_value=feature)
-        self.validate()
 
     def validate(self) -> None:
         super().validate()

--- a/sbol3/compref.py
+++ b/sbol3/compref.py
@@ -22,11 +22,11 @@ class ComponentReference(Feature):
         # Must have 1 feature
         if self.feature is None:
             message = 'ComponentReference must have a feature'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         # Must have 1 in_child_of
         if self.in_child_of is None:
             message = 'ComponentReference must have an in_child_of reference'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         return report
 
 

--- a/sbol3/compref.py
+++ b/sbol3/compref.py
@@ -17,15 +17,17 @@ class ComponentReference(Feature):
         self.feature = ReferencedObject(self, SBOL_FEATURES, 1, 1,
                                         initial_value=feature)
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         # Must have 1 feature
         if self.feature is None:
-            raise ValidationError('ComponentReference must have a feature')
+            message = 'ComponentReference must have a feature'
+            report.addError(None, message)
         # Must have 1 in_child_of
         if self.in_child_of is None:
-            msg = 'ComponentReference must have an in_child_of reference'
-            raise ValidationError(msg)
+            message = 'ComponentReference must have an in_child_of reference'
+            report.addError(None, message)
+        return report
 
 
 def build_component_reference(identity: str, *,

--- a/sbol3/constraint.py
+++ b/sbol3/constraint.py
@@ -20,13 +20,13 @@ class Constraint(Identified):
         report = super().validate(report)
         if not self.restriction:
             message = 'Constraint must have a restriction'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         if not self.subject:
             message = 'Constraint must have a subject'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         if not self.object:
             message = 'Constraint must have an object'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         return report
 
 

--- a/sbol3/constraint.py
+++ b/sbol3/constraint.py
@@ -16,14 +16,18 @@ class Constraint(Identified):
         self.object = ReferencedObject(self, SBOL_OBJECT, 1, 1,
                                        initial_value=object)
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         if not self.restriction:
-            raise ValidationError('Constraint must have a restriction')
+            message = 'Constraint must have a restriction'
+            report.addError(None, message)
         if not self.subject:
-            raise ValidationError('Constraint must have a subject')
+            message = 'Constraint must have a subject'
+            report.addError(None, message)
         if not self.object:
-            raise ValidationError('Constraint must have an object')
+            message = 'Constraint must have an object'
+            report.addError(None, message)
+        return report
 
 
 def build_constraint(identity: str, type_uri: str = SBOL_CONSTRAINT) -> SBOLObject:

--- a/sbol3/constraint.py
+++ b/sbol3/constraint.py
@@ -15,7 +15,6 @@ class Constraint(Identified):
                                         initial_value=subject)
         self.object = ReferencedObject(self, SBOL_OBJECT, 1, 1,
                                        initial_value=object)
-        self.validate()
 
     def validate(self) -> None:
         super().validate()

--- a/sbol3/custom.py
+++ b/sbol3/custom.py
@@ -11,10 +11,12 @@ class CustomIdentified(Identified):
         self.rdf_type = URIProperty(self, rdflib.RDF.type, 1, 1,
                                     initial_value=sbol_type_uri)
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         if self.rdf_type is None:
-            raise ValidationError('rdf_type is a required property of CustomIdentified')
+            message = 'rdf_type is a required property of CustomIdentified'
+            report.addError(None, message)
+        return report
 
 
 class CustomTopLevel(TopLevel):
@@ -25,7 +27,9 @@ class CustomTopLevel(TopLevel):
         self.rdf_type = URIProperty(self, rdflib.RDF.type, 1, 1,
                                     initial_value=sbol_type_uri)
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         if self.rdf_type is None:
-            raise ValidationError('rdf_type is a required property of CustomTopLevel')
+            message = 'rdf_type is a required property of CustomTopLevel'
+            report.addError(None, message)
+        return report

--- a/sbol3/custom.py
+++ b/sbol3/custom.py
@@ -15,7 +15,7 @@ class CustomIdentified(Identified):
         report = super().validate(report)
         if self.rdf_type is None:
             message = 'rdf_type is a required property of CustomIdentified'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         return report
 
 
@@ -31,5 +31,5 @@ class CustomTopLevel(TopLevel):
         report = super().validate(report)
         if self.rdf_type is None:
             message = 'rdf_type is a required property of CustomTopLevel'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         return report

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -312,3 +312,11 @@ class Document:
         """
         warnings.warn('Use Document.bind() instead', DeprecationWarning)
         self.bind(prefix, namespace)
+
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        """Validate all objects in this document."""
+        if report is None:
+            report = ValidationReport()
+        for obj in self.objects:
+            obj.validate(report)
+        return report

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -48,9 +48,9 @@ class Document:
             try:
                 other_type = types[0]
             except IndexError:
-                raise ValidationError('Expected one other type')
+                raise SBOLError('Custom object has only one RDF type')
             if other_type.startswith(SBOL3_NS):
-                raise ValidationError('Secondary type may not be in SBOL3 namespace')
+                raise SBOLError('Secondary type may not be in SBOL3 namespace')
             try:
                 builder = self._uri_type_map[other_type]
             except KeyError:
@@ -62,9 +62,9 @@ class Document:
             try:
                 other_type = types[0]
             except IndexError:
-                raise ValidationError('Expected one other type')
+                raise SBOLError('Custom object has only one RDF type')
             if other_type.startswith(SBOL3_NS):
-                raise ValidationError('Secondary type may not be in SBOL3 namespace')
+                raise SBOLError('Secondary type may not be in SBOL3 namespace')
             try:
                 builder = self._uri_type_map[other_type]
             except KeyError:
@@ -73,7 +73,7 @@ class Document:
             return builder(identity=identity, type_uri=other_type)
         else:
             message = 'Custom types must contain either Identified or TopLevel'
-            raise ValidationError(message)
+            raise SBOLError(message)
 
     def _parse_objects(self, graph: rdflib.Graph) -> Dict[str, SBOLObject]:
         # First extract the identities and their types. Each identity
@@ -95,13 +95,13 @@ class Document:
                     builder = self._uri_type_map[type_uri]
                 except KeyError:
                     logging.warning(f'No builder found for {type_uri}')
-                    raise ValidationError(f'Unknown type {type_uri}')
+                    raise SBOLError(f'Unknown type {type_uri}')
                 obj = builder(identity=identity, type_uri=type_uri)
             elif len(types) == 2:
                 obj = self._make_custom_object(identity, types)
             else:
                 message = f'Expected either 1 or 2 types for {identity}'
-                raise ValidationError(message)
+                raise SBOLError(message)
             obj.document = self
             result[obj.identity] = obj
         return result

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -153,8 +153,10 @@ class Document:
         self._parse_attributes(objects, graph)
         self._clean_up_singletons(objects)
         # Validate all the objects
-        for obj in objects.values():
-            obj.validate()
+        # TODO: Where does this belong? Is this automatic?
+        #       Or should a user invoke validate?
+        # for obj in objects.values():
+        #     obj.validate()
         # Store the TopLevel objects in the Document
         self.objects = [obj for uri, obj in objects.items()
                         if isinstance(obj, TopLevel)]

--- a/sbol3/error.py
+++ b/sbol3/error.py
@@ -4,7 +4,7 @@ class Error(Exception):
     pass
 
 
-class ValidationError(Error):
+class SBOLError(Error):
 
     def __init__(self, message: str):
         self.message = message

--- a/sbol3/extdef.py
+++ b/sbol3/extdef.py
@@ -21,7 +21,6 @@ class ExternallyDefined(Feature):
                                            initial_value=types)
         self.definition: uri_singleton = URIProperty(self, SBOL_DEFINITION, 1, 1,
                                                      initial_value=definition)
-        self.validate()
 
     def validate(self):
         super().validate()

--- a/sbol3/extdef.py
+++ b/sbol3/extdef.py
@@ -26,10 +26,10 @@ class ExternallyDefined(Feature):
         report = super().validate(report)
         if len(self.types) < 1:
             message = 'ExternallyDefined must contain at least 1 type'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         if self.definition is None:
             message = 'ExternallyDefined must have a definition'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         return report
 
 

--- a/sbol3/extdef.py
+++ b/sbol3/extdef.py
@@ -22,12 +22,15 @@ class ExternallyDefined(Feature):
         self.definition: uri_singleton = URIProperty(self, SBOL_DEFINITION, 1, 1,
                                                      initial_value=definition)
 
-    def validate(self):
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         if len(self.types) < 1:
-            raise ValidationError('ExternallyDefined must contain at least 1 type')
+            message = 'ExternallyDefined must contain at least 1 type'
+            report.addError(None, message)
         if self.definition is None:
-            raise ValidationError('ExternallyDefined must have a definition')
+            message = 'ExternallyDefined must have a definition'
+            report.addError(None, message)
+        return report
 
 
 def build_externally_defined(identity: str,

--- a/sbol3/feature.py
+++ b/sbol3/feature.py
@@ -12,11 +12,12 @@ class Feature(Identified, abc.ABC):
         self.roles = URIProperty(self, SBOL_ROLE, 0, math.inf)
         self.orientation = URIProperty(self, SBOL_ORIENTATION, 0, 1)
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         # If there is an orientation, it must be in the valid set
         if self.orientation is not None:
             valid_orientations = [SBOL_INLINE, SBOL_REVERSE_COMPLEMENT]
             if self.orientation not in valid_orientations:
                 message = f'{self.orientation} is not a valid orientation'
-                raise ValidationError(message)
+                report.addError(None, message)
+        return report

--- a/sbol3/feature.py
+++ b/sbol3/feature.py
@@ -19,5 +19,5 @@ class Feature(Identified, abc.ABC):
             valid_orientations = [SBOL_INLINE, SBOL_REVERSE_COMPLEMENT]
             if self.orientation not in valid_orientations:
                 message = f'{self.orientation} is not a valid orientation'
-                report.addError(None, message)
+                report.addError(self.identity, None, message)
         return report

--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -112,7 +112,12 @@ class Identified(SBOLObject):
     def validate(self, report: ValidationReport = None) -> ValidationReport:
         if report is None:
             report = ValidationReport()
+        # Do validations for Identified
         self._validate_display_id(report)
+        # Validate all owned objects
+        for object_list in self._owned_objects.values():
+            for obj in object_list:
+                obj.validate(report)
         return report
 
     def serialize(self, graph: rdflib.Graph):

--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -71,7 +71,7 @@ class Identified(SBOLObject):
             if Identified._is_valid_display_id(self.display_id):
                 return
         message = f'{self.display_id} is not a valid displayId for {self.identity}'
-        report.addError(None, message)
+        report.addError(self.identity, None, message)
 
     def _update_identity(self, identity: str, display_id: str) -> None:
         """Updates the identity of an Identified when it is added to a

--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -61,7 +61,7 @@ class Identified(SBOLObject):
             msg += ' or underscore characters and MUST NOT begin with a digit.'
             raise ValueError(msg)
 
-    def _validate_display_id(self) -> None:
+    def _validate_display_id(self, report: ValidationReport) -> None:
         if self.identity_is_url():
             if (self.display_id is not None and
                     Identified._is_valid_display_id(self.display_id) and
@@ -71,7 +71,7 @@ class Identified(SBOLObject):
             if Identified._is_valid_display_id(self.display_id):
                 return
         message = f'{self.display_id} is not a valid displayId for {self.identity}'
-        raise ValidationError(message)
+        report.addError(None, message)
 
     def _update_identity(self, identity: str, display_id: str) -> None:
         """Updates the identity of an Identified when it is added to a
@@ -109,9 +109,11 @@ class Identified(SBOLObject):
         # display_id is a read only property
         return self._display_id
 
-    def validate(self) -> None:
-        super().validate()
-        self._validate_display_id()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        if report is None:
+            report = ValidationReport()
+        self._validate_display_id(report)
+        return report
 
     def serialize(self, graph: rdflib.Graph):
         identity = rdflib.URIRef(self.identity)

--- a/sbol3/implementation.py
+++ b/sbol3/implementation.py
@@ -6,10 +6,9 @@ class Implementation(TopLevel):
     def __init__(self, identity: str, *, type_uri: str = SBOL_IMPLEMENTATION) -> None:
         super().__init__(identity, type_uri)
         self.built = ReferencedObject(self, SBOL_BUILT, 0, 1)
-        self.validate()
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport) -> None:
+        super().validate(report)
 
 
 Document.register_builder(SBOL_IMPLEMENTATION, Implementation)

--- a/sbol3/implementation.py
+++ b/sbol3/implementation.py
@@ -7,8 +7,5 @@ class Implementation(TopLevel):
         super().__init__(identity, type_uri)
         self.built = ReferencedObject(self, SBOL_BUILT, 0, 1)
 
-    def validate(self, report: ValidationReport) -> None:
-        super().validate(report)
-
 
 Document.register_builder(SBOL_IMPLEMENTATION, Implementation)

--- a/sbol3/interaction.py
+++ b/sbol3/interaction.py
@@ -15,9 +15,6 @@ class Interaction(Identified):
         self.participations = OwnedObject(self, SBOL_PARTICIPATIONS, 0, math.inf,
                                           type_constraint=Participation)
 
-    def validate(self) -> None:
-        super().validate()
-
 
 def build_interaction(identity: str, *, type_uri: str = SBOL_INTERACTION) -> SBOLObject:
     interaction_type = PYSBOL3_MISSING

--- a/sbol3/interface.py
+++ b/sbol3/interface.py
@@ -12,9 +12,6 @@ class Interface(Identified):
         self.output = ReferencedObject(self, SBOL_OUTPUT, 0, math.inf)
         self.non_directional = ReferencedObject(self, SBOL_NON_DIRECTIONAL, 0, math.inf)
 
-    def validate(self) -> None:
-        super().validate()
-
 
 def build_interface(identity: str, *, type_uri: str = SBOL_INTERFACE) -> SBOLObject:
     return Interface(identity=identity, type_uri=type_uri)

--- a/sbol3/interface.py
+++ b/sbol3/interface.py
@@ -11,7 +11,6 @@ class Interface(Identified):
         self.input = ReferencedObject(self, SBOL_INPUT, 0, math.inf)
         self.output = ReferencedObject(self, SBOL_OUTPUT, 0, math.inf)
         self.non_directional = ReferencedObject(self, SBOL_NON_DIRECTIONAL, 0, math.inf)
-        self.validate()
 
     def validate(self) -> None:
         super().validate()

--- a/sbol3/localsub.py
+++ b/sbol3/localsub.py
@@ -16,7 +16,6 @@ class LocalSubComponent(Feature):
                                            initial_value=types)
         self.locations = OwnedObject(self, SBOL_LOCATION, 0, math.inf,
                                      type_constraint=Location)
-        self.validate()
 
     def validate(self, report: ValidationReport = None) -> ValidationReport:
         report = super().validate(report)

--- a/sbol3/localsub.py
+++ b/sbol3/localsub.py
@@ -21,7 +21,7 @@ class LocalSubComponent(Feature):
         report = super().validate(report)
         if len(self.types) < 1:
             message = 'LocalSubComponent must have at least 1 type'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         return report
 
 

--- a/sbol3/localsub.py
+++ b/sbol3/localsub.py
@@ -18,10 +18,12 @@ class LocalSubComponent(Feature):
                                      type_constraint=Location)
         self.validate()
 
-    def validate(self):
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         if len(self.types) < 1:
-            raise ValidationError('LocalSubComponent must have at least 1 type')
+            message = 'LocalSubComponent must have at least 1 type'
+            report.addError(None, message)
+        return report
 
 
 def build_local_subcomponent(identity: str,

--- a/sbol3/location.py
+++ b/sbol3/location.py
@@ -33,7 +33,6 @@ class Range(Location):
                                                initial_value=start)
         self.end: int_property = IntProperty(self, SBOL_END, 1, 1,
                                              initial_value=end)
-        self.validate()
 
     def validate(self, report: ValidationReport = None) -> ValidationReport:
         report = super().validate(report)
@@ -101,7 +100,6 @@ class EntireSequence(Location):
                  *, identity: str = None,
                  type_uri: str = SBOL_ENTIRE_SEQUENCE) -> None:
         super().__init__(seq_or_uri, identity, type_uri)
-        self.validate()
 
 
 def build_entire_sequence(identity: str, type_uri: str = SBOL_ENTIRE_SEQUENCE):

--- a/sbol3/location.py
+++ b/sbol3/location.py
@@ -20,7 +20,7 @@ class Location(Identified, abc.ABC):
         report = super().validate(report)
         if not self.sequence:
             message = f'Location {self.identity} does not have a sequence'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         return report
 
 
@@ -37,14 +37,16 @@ class Range(Location):
     def validate(self, report: ValidationReport = None) -> ValidationReport:
         report = super().validate(report)
         if self.start < 1:
-            message = 'Start must be greater than 0'
-            report.addError(None, message)
+            message = 'Range.start must be greater than 0'
+            report.addError(self.identity, 'sbol3-11401', message)
+        # TODO: start must also be less than or equal to len(sequence)
         if self.end < 1:
-            message = 'End must be greater than 0'
-            report.addError(None, message)
+            message = 'Range.end must be greater than 0'
+            report.addError(self.identity, 'sbol3-11402', message)
+        # TODO: end must also be less than or equal to len(sequence)
         if self.end < self.start:
-            message = 'End must be >= start'
-            report.addError(None, message)
+            message = 'Range.end must be >= start'
+            report.addError(self.identity, 'sbol3-11403', message)
         return report
 
 
@@ -76,7 +78,7 @@ class Cut(Location):
         report = super().validate(report)
         if self.at < 0:
             message = 'Cut property "at" must be >= 0'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         return report
 
 

--- a/sbol3/location.py
+++ b/sbol3/location.py
@@ -17,7 +17,7 @@ class Location(Identified, abc.ABC):
                                          initial_value=seq_or_uri)
 
     def validate(self, report: ValidationReport = None) -> ValidationReport:
-        report = super().validate()
+        report = super().validate(report)
         if not self.sequence:
             message = f'Location {self.identity} does not have a sequence'
             report.addError(None, message)

--- a/sbol3/location.py
+++ b/sbol3/location.py
@@ -16,10 +16,12 @@ class Location(Identified, abc.ABC):
         self.sequence = ReferencedObject(self, SBOL_SEQUENCES, 1, 1,
                                          initial_value=seq_or_uri)
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate()
         if not self.sequence:
-            raise ValidationError(f'Location {self.identity} does not have a sequence')
+            message = f'Location {self.identity} does not have a sequence'
+            report.addError(None, message)
+        return report
 
 
 class Range(Location):
@@ -33,14 +35,18 @@ class Range(Location):
                                              initial_value=end)
         self.validate()
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         if self.start < 1:
-            raise ValidationError('Start must be greater than 0')
+            message = 'Start must be greater than 0'
+            report.addError(None, message)
         if self.end < 1:
-            raise ValidationError('Start must be greater than 0')
+            message = 'End must be greater than 0'
+            report.addError(None, message)
         if self.end < self.start:
-            raise ValidationError('End must be >= start')
+            message = 'End must be >= start'
+            report.addError(None, message)
+        return report
 
 
 def build_range(identity: str, type_uri: str = SBOL_RANGE):
@@ -66,12 +72,13 @@ class Cut(Location):
         super().__init__(seq_or_uri, identity, type_uri)
         self.at: int_property = IntProperty(self, SBOL_START, 1, 1,
                                             initial_value=at)
-        self.validate()
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         if self.at < 0:
-            raise ValidationError('At must be >= 0')
+            message = 'Cut property "at" must be >= 0'
+            report.addError(None, message)
+        return report
 
 
 def build_cut(identity: str, type_uri: str = SBOL_CUT):

--- a/sbol3/model.py
+++ b/sbol3/model.py
@@ -9,20 +9,21 @@ class Model(TopLevel):
         self.language = URIProperty(self, SBOL_LANGUAGE, 1, 1)
         self.framework = URIProperty(self, SBOL_FRAMEWORK, 1, 1)
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         # The source property is REQUIRED and MUST contain a URI reference (Section 6.8)
         if not self.source:
             msg = f'Model {self.identity} does not have a source'
-            raise ValidationError(msg)
+            report.addError(None, msg)
         # The language property is REQUIRED and MUST contain a URI (Section 6.8)
         if not self.language:
             msg = f'Model {self.identity} does not have a language'
-            raise ValidationError(msg)
+            report.addError(None, msg)
         # The framework property is REQUIRED and MUST contain a URI (Section 6.8)
         if not self.framework:
             msg = f'Model {self.identity} does not have a framework'
-            raise ValidationError(msg)
+            report.addError(None, msg)
+        return report
 
 
 Document.register_builder(SBOL_MODEL, Model)

--- a/sbol3/model.py
+++ b/sbol3/model.py
@@ -14,15 +14,15 @@ class Model(TopLevel):
         # The source property is REQUIRED and MUST contain a URI reference (Section 6.8)
         if not self.source:
             msg = f'Model {self.identity} does not have a source'
-            report.addError(None, msg)
+            report.addError(self.identity, None, msg)
         # The language property is REQUIRED and MUST contain a URI (Section 6.8)
         if not self.language:
             msg = f'Model {self.identity} does not have a language'
-            report.addError(None, msg)
+            report.addError(self.identity, None, msg)
         # The framework property is REQUIRED and MUST contain a URI (Section 6.8)
         if not self.framework:
             msg = f'Model {self.identity} does not have a framework'
-            report.addError(None, msg)
+            report.addError(self.identity, None, msg)
         return report
 
 

--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -37,11 +37,6 @@ class SBOLObject:
             result = result.get()
         return result
 
-    def _validate_identity(self) -> None:
-        # TODO: identity must be a URI
-        # TODO: can identity be None?
-        pass
-
     @staticmethod
     def _is_url(name: str) -> bool:
         parsed = urlparse(name)
@@ -80,9 +75,6 @@ class SBOLObject:
             return base_uri + name
         else:
             return posixpath.join(base_uri, name.lstrip(posixpath.sep))
-
-    def validate(self) -> None:
-        self._validate_identity()
 
     @property
     def identity(self) -> str:

--- a/sbol3/om_compound.py
+++ b/sbol3/om_compound.py
@@ -23,7 +23,6 @@ class UnitMultiplication(CompoundUnit):
                                       initial_value=term1)
         self.term2 = ReferencedObject(self, OM_HAS_TERM2, 1, 1,
                                       initial_value=term2)
-        self.validate()
 
 
 def build_unit_multiplication(identity: str,
@@ -52,7 +51,6 @@ class UnitDivision(CompoundUnit):
                                           initial_value=numerator)
         self.denominator = ReferencedObject(self, OM_HAS_DENOMINATOR, 1, 1,
                                             initial_value=denominator)
-        self.validate()
 
 
 def build_unit_division(identity: str,
@@ -80,7 +78,6 @@ class UnitExponentiation(CompoundUnit):
                                      initial_value=base)
         self.exponent = IntProperty(self, OM_HAS_EXPONENT, 1, 1,
                                     initial_value=exponent)
-        self.validate()
 
 
 def build_unit_exponentiation(identity: str,

--- a/sbol3/om_prefix.py
+++ b/sbol3/om_prefix.py
@@ -41,7 +41,6 @@ class SIPrefix(Prefix):
     def __init__(self, identity: str, symbol: str, label: str,
                  factor: float, *, type_uri: str = OM_SI_PREFIX) -> None:
         super().__init__(identity, symbol, label, factor, type_uri)
-        self.validate()
 
 
 def build_si_prefix(identity: str, *, type_uri: str = OM_SI_PREFIX) -> SBOLObject:
@@ -62,7 +61,6 @@ class BinaryPrefix(Prefix):
     def __init__(self, identity: str, symbol: str, label: str,
                  factor: float, *, type_uri: str = OM_BINARY_PREFIX) -> None:
         super().__init__(identity, symbol, label, factor, type_uri)
-        self.validate()
 
 
 def build_binary_prefix(identity: str,

--- a/sbol3/om_prefix.py
+++ b/sbol3/om_prefix.py
@@ -30,13 +30,13 @@ class Prefix(CustomTopLevel, abc.ABC):
         report = super().validate(report)
         if not self.symbol:
             message = 'Prefix must contain a symbol'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         if not self.label:
             message = 'Prefix must contain a label'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         if not self.factor:
             message = 'Prefix must contain a factor'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         return report
 
 

--- a/sbol3/om_prefix.py
+++ b/sbol3/om_prefix.py
@@ -26,14 +26,18 @@ class Prefix(CustomTopLevel, abc.ABC):
         self.factor = FloatProperty(self, OM_HAS_FACTOR, 1, 1,
                                     initial_value=factor)
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         if not self.symbol:
-            raise ValidationError('Prefix must contain a symbol')
+            message = 'Prefix must contain a symbol'
+            report.addError(None, message)
         if not self.label:
-            raise ValidationError('Prefix must contain a label')
+            message = 'Prefix must contain a label'
+            report.addError(None, message)
         if not self.factor:
-            raise ValidationError('Prefix must contain a factor')
+            message = 'Prefix must contain a factor'
+            report.addError(None, message)
+        return report
 
 
 class SIPrefix(Prefix):

--- a/sbol3/om_unit.py
+++ b/sbol3/om_unit.py
@@ -38,7 +38,6 @@ class Measure(CustomIdentified):
         self.types = URIProperty(self, SBOL_TYPE, 0, math.inf)
         self.unit = URIProperty(self, OM_HAS_UNIT, 1, 1,
                                 initial_value=unit)
-        self.validate()
 
 
 def build_measure(identity: str, *, type_uri: str = OM_MEASURE) -> SBOLObject:
@@ -60,7 +59,6 @@ class SingularUnit(Unit):
         super().__init__(identity, symbol, label, type_uri)
         self.unit = ReferencedObject(self, OM_HAS_UNIT, 0, 1)
         self.factor = FloatProperty(self, OM_HAS_FACTOR, 0, 1)
-        self.validate()
 
 
 def build_singular_unit(identity: str,
@@ -87,7 +85,6 @@ class PrefixedUnit(Unit):
                                      initial_value=unit)
         self.prefix = ReferencedObject(self, OM_HAS_PREFIX, 1, 1,
                                        initial_value=prefix)
-        self.validate()
 
 
 def build_prefixed_unit(identity: str,

--- a/sbol3/ownedobject.py
+++ b/sbol3/ownedobject.py
@@ -40,7 +40,7 @@ class OwnedObjectPropertyMixin:
             if sibling == item:
                 continue
             if sibling.identity == new_url:
-                raise ValidationError(f'Duplicate URI: {new_url}')
+                raise ValueError(f'Duplicate URI: {new_url}')
         item._update_identity(new_url, new_display_id)
 
 

--- a/sbol3/participation.py
+++ b/sbol3/participation.py
@@ -15,7 +15,6 @@ class Participation(Identified):
                                            initial_value=roles)
         self.participant = ReferencedObject(self, SBOL_PARTICIPANT, 1, 1,
                                             initial_value=participant)
-        self.validate()
 
     def validate(self) -> None:
         super().validate()

--- a/sbol3/participation.py
+++ b/sbol3/participation.py
@@ -20,10 +20,10 @@ class Participation(Identified):
         report = super().validate(report)
         if len(self.roles) < 1:
             message = 'Participation must have at least one role'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         if self.participant is None:
             message = 'Participation must have a participant'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         return report
 
 

--- a/sbol3/participation.py
+++ b/sbol3/participation.py
@@ -16,12 +16,15 @@ class Participation(Identified):
         self.participant = ReferencedObject(self, SBOL_PARTICIPANT, 1, 1,
                                             initial_value=participant)
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         if len(self.roles) < 1:
-            raise ValidationError('Participation must have at least one role')
+            message = 'Participation must have at least one role'
+            report.addError(None, message)
         if self.participant is None:
-            raise ValidationError('Participation must have a participant')
+            message = 'Participation must have a participant'
+            report.addError(None, message)
+        return report
 
 
 def build_participation(identity: str,

--- a/sbol3/provenance.py
+++ b/sbol3/provenance.py
@@ -12,7 +12,6 @@ class Usage(CustomIdentified):
         self.entity = URIProperty(self, PROV_ENTITY, 1, 1,
                                   initial_value=entity)
         self.roles = URIProperty(self, PROV_ROLES, 0, math.inf)
-        self.validate()
 
 
 def build_usage(identity: str, *, type_uri: str = PROV_USAGE) -> SBOLObject:
@@ -30,7 +29,6 @@ class Agent(CustomTopLevel):
 
     def __init__(self, identity: str, *, type_uri: str = PROV_AGENT) -> None:
         super().__init__(identity, type_uri)
-        self.validate()
 
 
 Document.register_builder(PROV_AGENT, Agent)
@@ -40,7 +38,6 @@ class Plan(CustomTopLevel):
 
     def __init__(self, identity: str, *, type_uri: str = PROV_PLAN) -> None:
         super().__init__(identity, type_uri)
-        self.validate()
 
 
 Document.register_builder(PROV_PLAN, Plan)
@@ -56,7 +53,6 @@ class Association(CustomIdentified):
         self.plan = ReferencedObject(self, PROV_PLANS, 0, 1)
         self.agent = ReferencedObject(self, PROV_AGENTS, 1, 1,
                                       initial_value=agent)
-        self.validate()
 
 
 def build_association(identity: str, *, type_uri: str = PROV_USAGE) -> SBOLObject:
@@ -81,7 +77,6 @@ class Activity(CustomTopLevel):
                                  type_constraint=Usage)
         self.association = OwnedObject(self, PROV_QUALIFIED_ASSOCIATION, 0, math.inf,
                                        type_constraint=Association)
-        self.validate()
 
 
 Document.register_builder(PROV_ACTIVITY, Activity)

--- a/sbol3/seqfeat.py
+++ b/sbol3/seqfeat.py
@@ -17,12 +17,13 @@ class SequenceFeature(Feature):
                                               1, math.inf,
                                               type_constraint=Location,
                                               initial_value=locations)
-        self.validate()
 
-    def validate(self):
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         if len(self.locations) < 1:
-            raise ValidationError('LocalSubComponent must have at least 1 location')
+            message = 'LocalSubComponent must have at least 1 location'
+            report.addError(None, message)
+        return report
 
 
 def build_sequence_feature(identity: str,

--- a/sbol3/seqfeat.py
+++ b/sbol3/seqfeat.py
@@ -22,7 +22,7 @@ class SequenceFeature(Feature):
         report = super().validate(report)
         if len(self.locations) < 1:
             message = 'LocalSubComponent must have at least 1 location'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         return report
 
 

--- a/sbol3/sequence.py
+++ b/sbol3/sequence.py
@@ -13,7 +13,7 @@ class Sequence(TopLevel):
         # If sequence is set, encoding is REQUIRED
         if self.elements and not self.encoding:
             message = 'Sequence encoding is required if elements are set'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         return report
 
 

--- a/sbol3/sequence.py
+++ b/sbol3/sequence.py
@@ -7,13 +7,14 @@ class Sequence(TopLevel):
         super().__init__(identity, type_uri)
         self.elements = TextProperty(self, SBOL_ELEMENTS, 0, 1)
         self.encoding = URIProperty(self, SBOL_ENCODING, 0, 1)
-        self.validate()
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         # If sequence is set, encoding is REQUIRED
         if self.elements and not self.encoding:
-            raise ValidationError('Sequence encoding is required if elements are set')
+            message = 'Sequence encoding is required if elements are set'
+            report.addError(None, message)
+        return report
 
 
 Document.register_builder(SBOL_SEQUENCE, Sequence)

--- a/sbol3/subcomponent.py
+++ b/sbol3/subcomponent.py
@@ -24,7 +24,7 @@ class SubComponent(Feature):
         # The instance_of property is required
         if not self.instance_of:
             message = 'SubComponent must have an instance_of'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         return report
 
 

--- a/sbol3/subcomponent.py
+++ b/sbol3/subcomponent.py
@@ -18,13 +18,14 @@ class SubComponent(Feature):
                                             type_constraint=Location)
         self.locations = OwnedObject(self, SBOL_LOCATION, 0, math.inf,
                                      type_constraint=Location)
-        self.validate()
 
-    def validate(self) -> None:
-        super().validate()
-        # If there is an orientation, it must be in the valid set
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
+        # The instance_of property is required
         if not self.instance_of:
-            raise ValidationError('SubComponent must have an instance_of')
+            message = 'SubComponent must have an instance_of'
+            report.addError(None, message)
+        return report
 
 
 def build_subcomponent(identity: str, type_uri: str = SBOL_SUBCOMPONENT) -> Identified:

--- a/sbol3/toplevel.py
+++ b/sbol3/toplevel.py
@@ -14,9 +14,10 @@ class TopLevel(Identified):
         super().__init__(identity, type_uri)
         self.attachments = ReferencedObject(self, SBOL_HAS_ATTACHMENT, 0, math.inf)
 
-    def validate_identity(self) -> None:
+    def validate_identity(self, report: ValidationReport) -> None:
         # TODO: See section 5.1 for rules about identity for TopLevel
-        super().validate_identity()
+        pass
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
+        return report

--- a/sbol3/validation.py
+++ b/sbol3/validation.py
@@ -5,18 +5,26 @@ class ValidationError:
     """A ValidationError is a violation of the SBOL specification.
     """
 
-    def __init__(self, code, message):
-        self.code = code
+    def __init__(self, object_id, rule_id, message):
+        self.rule_id = rule_id
         self.message = message
+        self.object_id = object_id
+
+    def __str__(self):
+        result = f'{self.rule_id}: {self.message}'
+        if self.object_id is not None:
+            result = f'{self.object_id} {result}'
+        return result
 
 
 class ValidationWarning:
     """A ValidationWarning is a violation of an SBOL best practice.
     """
 
-    def __init__(self, code, message):
-        self.code = code
+    def __init__(self, object_id, rule_id, message):
+        self.rule_id = rule_id
         self.message = message
+        self.object_id = object_id
 
 
 class ValidationReport:
@@ -36,8 +44,8 @@ class ValidationReport:
     def errors(self) -> Sequence[ValidationError]:
         return tuple(self._errors)
 
-    def addError(self, code, message):
-        self._errors.append(ValidationError(code, message))
+    def addError(self, object_id, rule_id, message):
+        self._errors.append(ValidationError(object_id, rule_id, message))
 
-    def addWarning(self, code, message):
-        self._warnings.append(ValidationWarning(code, message))
+    def addWarning(self, object_id, rule_id, message):
+        self._warnings.append(ValidationWarning(object_id, rule_id, message))

--- a/sbol3/validation.py
+++ b/sbol3/validation.py
@@ -1,7 +1,5 @@
 from typing import Sequence
 
-# TODO: Find all self calls to validate, remove them
-#    grep 'self.validate()' sbol3/*.py
 # TODO: Find all calls to super validate, make sure they pass report
 #    grep super sbol3/*.py | grep validate
 # TODO: Deconflict error.ValidationError and validation.ValidationError

--- a/sbol3/validation.py
+++ b/sbol3/validation.py
@@ -1,0 +1,42 @@
+from typing import Sequence
+
+# TODO: Find all self calls to validate, remove them
+#    grep 'self.validate()' sbol3/*.py
+# TODO: Find all calls to super validate, make sure they pass report
+#    grep super sbol3/*.py | grep validate
+# TODO: Deconflict error.ValidationError and validation.ValidationError
+
+
+class ValidationError:
+
+    def __init__(self, code, message):
+        self.code = code
+        self.message = message
+
+
+class ValidationWarning:
+
+    def __init__(self, code, message):
+        self.code = code
+        self.message = message
+
+
+class ValidationReport:
+
+    def __init__(self):
+        self._errors = []
+        self._warnings = []
+
+    @property
+    def warnings(self) -> Sequence[ValidationWarning]:
+        return tuple(self._warnings)
+
+    @property
+    def errors(self) -> Sequence[ValidationError]:
+        return tuple(self._errors)
+
+    def addError(self, code, message):
+        self._errors.append(ValidationError(code, message))
+
+    def addWarning(self, code, message):
+        self._warnings.append(ValidationWarning(code, message))

--- a/sbol3/validation.py
+++ b/sbol3/validation.py
@@ -1,11 +1,9 @@
 from typing import Sequence
 
-# TODO: Find all calls to super validate, make sure they pass report
-#    grep super sbol3/*.py | grep validate
-# TODO: Deconflict error.ValidationError and validation.ValidationError
-
 
 class ValidationError:
+    """A ValidationError is a violation of the SBOL specification.
+    """
 
     def __init__(self, code, message):
         self.code = code
@@ -13,6 +11,8 @@ class ValidationError:
 
 
 class ValidationWarning:
+    """A ValidationWarning is a violation of an SBOL best practice.
+    """
 
     def __init__(self, code, message):
         self.code = code

--- a/sbol3/validation.py
+++ b/sbol3/validation.py
@@ -25,6 +25,12 @@ class ValidationReport:
         self._errors = []
         self._warnings = []
 
+    def __bool__(self):
+        return bool(self._errors or self._warnings)
+
+    def __len__(self):
+        return len(self._errors) + len(self._warnings)
+
     @property
     def warnings(self) -> Sequence[ValidationWarning]:
         return tuple(self._warnings)

--- a/sbol3/validation.py
+++ b/sbol3/validation.py
@@ -25,9 +25,6 @@ class ValidationReport:
         self._errors = []
         self._warnings = []
 
-    def __bool__(self):
-        return bool(self._errors or self._warnings)
-
     def __len__(self):
         return len(self._errors) + len(self._warnings)
 

--- a/sbol3/varcomp.py
+++ b/sbol3/varcomp.py
@@ -36,10 +36,10 @@ class VariableFeature(Identified):
                                SBOL_ZERO_OR_ONE]
         if self.cardinality not in valid_cardinalities:
             message = f'{self.cardinality} is not a valid cardinality'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         if self.variable is None:
             message = 'VariableComponent.variable is required'
-            report.addError(None, message)
+            report.addError(self.identity, None, message)
         return report
 
 

--- a/sbol3/varcomp.py
+++ b/sbol3/varcomp.py
@@ -28,18 +28,19 @@ class VariableFeature(Identified):
                                                     0, math.inf)
         self.variant_measures = OwnedObject(self, SBOL_VARIANT_MEASURE,
                                             0, math.inf)
-        # Validate
-        self.validate()
 
-    def validate(self) -> None:
-        super().validate()
+    def validate(self, report: ValidationReport = None) -> ValidationReport:
+        report = super().validate(report)
         # Cardinality must be in the set of valid URIs
         valid_cardinalities = [SBOL_ONE, SBOL_ONE_OR_MORE, SBOL_ZERO_OR_MORE,
                                SBOL_ZERO_OR_ONE]
         if self.cardinality not in valid_cardinalities:
-            raise ValidationError(f'{self.cardinality} is not a valid cardinality')
+            message = f'{self.cardinality} is not a valid cardinality'
+            report.addError(None, message)
         if self.variable is None:
-            raise ValidationError('VariableComponent.variable is required')
+            message = 'VariableComponent.variable is required'
+            report.addError(None, message)
+        return report
 
 
 Document.register_builder(SBOL_VARIABLE_FEATURE, VariableFeature)

--- a/test/test_combderiv.py
+++ b/test/test_combderiv.py
@@ -26,8 +26,9 @@ class TestCombinatorialDerivation(unittest.TestCase):
         comp1 = sbol3.Component('comp1', sbol3.SBO_DNA)
         cd1 = sbol3.CombinatorialDerivation('cd1', comp1)
         cd1.strategy = sbol3.SBOL_INLINE
-        with self.assertRaises(sbol3.ValidationError):
-            cd1.validate()
+        report = cd1.validate()
+        self.assertIsNotNone(report)
+        self.assertEqual(1, len(report.errors))
 
     def test_round_trip(self):
         # See https://github.com/SynBioDex/pySBOL3/issues/156

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -174,6 +174,25 @@ class TestDocument(unittest.TestCase):
         actual = doc.write_string(sbol3.SORTED_NTRIPLES)
         self.assertEqual(expected, actual)
 
+    def test_validate(self):
+        # Test the document level validation
+        # This should validate all the objects in the document
+        # and return a report containing all errors and warnings.
+        doc = sbol3.Document()
+        c1 = sbol3.Component('https://github.com/synbiodex/pysbol3/c1',
+                             sbol3.SBO_DNA)
+        doc.add(c1)
+        s1 = sbol3.Sequence('https://github.com/synbiodex/pysbol3/s1')
+        doc.add(s1)
+        start = 10
+        end = 1
+        r = sbol3.Range(s1, start, end)
+        sf = sbol3.SequenceFeature([r])
+        c1.features.append(sf)
+        report = doc.validate()
+        # We should find the validation issue in the range
+        self.assertEqual(1, len(report))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_localsub.py
+++ b/test/test_localsub.py
@@ -20,8 +20,10 @@ class TestLocalSubComponent(unittest.TestCase):
 
     def test_validation(self):
         types = []
-        with self.assertRaises(sbol3.ValidationError):
-            sbol3.LocalSubComponent(types)
+        lsc = sbol3.LocalSubComponent(types)
+        report = lsc.validate()
+        self.assertIsNotNone(report)
+        self.assertEqual(1, len(report.errors))
 
 
 if __name__ == '__main__':

--- a/test/test_location.py
+++ b/test/test_location.py
@@ -22,22 +22,35 @@ class TestRange(unittest.TestCase):
     def test_invalid_create(self):
         start = 0
         end = 10
-        with self.assertRaises(sbol3.ValidationError):
-            sbol3.Range(sbol3.PYSBOL3_MISSING, start, end)
+        r = sbol3.Range(sbol3.PYSBOL3_MISSING, start, end)
+        report = r.validate()
+        self.assertIsNotNone(report)
+        self.assertEqual(1, len(report.errors))
+
+        # end must be > 0, and end must be > start
         start = 1
         end = 0
-        with self.assertRaises(sbol3.ValidationError):
-            sbol3.Range(sbol3.PYSBOL3_MISSING, start, end)
+        r = sbol3.Range(sbol3.PYSBOL3_MISSING, start, end)
+        report = r.validate()
+        self.assertIsNotNone(report)
+        self.assertEqual(2, len(report.errors))
+
         # end must be >= start
         start = 10
         end = 9
-        with self.assertRaises(sbol3.ValidationError):
-            sbol3.Range(sbol3.PYSBOL3_MISSING, start, end)
+        r = sbol3.Range(sbol3.PYSBOL3_MISSING, start, end)
+        report = r.validate()
+        self.assertIsNotNone(report)
+        self.assertEqual(1, len(report.errors))
+
         start = 7
         end = 7
         r = sbol3.Range(sbol3.PYSBOL3_MISSING, start, end)
         self.assertEqual(start, r.start)
         self.assertEqual(end, r.end)
+        report = r.validate()
+        self.assertIsNotNone(report)
+        self.assertEqual(0, len(report.errors))
 
 
 class TestCut(unittest.TestCase):
@@ -61,8 +74,10 @@ class TestCut(unittest.TestCase):
     def test_invalid_create(self):
         # At must be >= 0
         at = -1
-        with self.assertRaises(sbol3.ValidationError):
-            sbol3.Cut(sbol3.PYSBOL3_MISSING, at)
+        cut = sbol3.Cut(sbol3.PYSBOL3_MISSING, at)
+        report = cut.validate()
+        self.assertIsNotNone(report)
+        self.assertEqual(1, len(report.errors))
 
 
 class TestEntireSequence(unittest.TestCase):

--- a/test/test_seqfeat.py
+++ b/test/test_seqfeat.py
@@ -19,8 +19,10 @@ class TestSequenceFeature(unittest.TestCase):
 
     def test_validation(self):
         locations = []
-        with self.assertRaises(sbol3.ValidationError):
-            sbol3.SequenceFeature(locations)
+        sf = sbol3.SequenceFeature(locations)
+        report = sf.validate()
+        self.assertIsNotNone(report)
+        self.assertEqual(1, len(report.errors))
 
 
 if __name__ == '__main__':

--- a/test/test_seqfeat.py
+++ b/test/test_seqfeat.py
@@ -24,6 +24,22 @@ class TestSequenceFeature(unittest.TestCase):
         self.assertIsNotNone(report)
         self.assertEqual(1, len(report.errors))
 
+    def test_recursive_validation(self):
+        # Test that the owned object, in this case the Range,
+        # is also validated when the SequenceFeature is validated.
+        seq_uri = 'https://github.com/synbiodex/pysbol3/sequence'
+        start = 10
+        end = 1
+        r = sbol3.Range(seq_uri, start, end)
+        report = r.validate()
+        # end < start is a validation error
+        self.assertEqual(1, len(report.errors))
+        sf = sbol3.SequenceFeature([r])
+        report = sf.validate()
+        # We should find the validation issue in the owned
+        # object (the range).
+        self.assertEqual(1, len(report.errors))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_sequence.py
+++ b/test/test_sequence.py
@@ -26,8 +26,9 @@ class TestSequence(unittest.TestCase):
         seq = sbol3.Sequence(display_id)
         self.assertIsNotNone(seq)
         seq.elements = 'actg'
-        with self.assertRaises(sbol3.ValidationError):
-            seq.validate()
+        report = seq.validate()
+        self.assertIsNotNone(report)
+        self.assertEqual(1, len(report.errors))
 
     def test_valid(self):
         sbol3.set_namespace('https://github.com/synbiodex/pysbol3')

--- a/test/test_subcomponent.py
+++ b/test/test_subcomponent.py
@@ -22,8 +22,10 @@ class TestSubComponent(unittest.TestCase):
 
     def test_invalid_create(self):
         # SubComponent requires an `instance_of` argument
-        with self.assertRaises(sbol3.ValidationError):
-            sbol3.SubComponent('')
+        sc = sbol3.SubComponent('')
+        report = sc.validate()
+        self.assertIsNotNone(report)
+        self.assertEqual(1, len(report.errors))
 
     def test_external_instance_of(self):
         # See https://github.com/SynBioDex/pySBOL3/issues/136

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -10,25 +10,25 @@ class TestValidationReport(unittest.TestCase):
         report = sbol3.ValidationReport()
         self.assertEqual(False, bool(report))
         # True if any errors
-        report.addError(None, 'Fake error')
+        report.addError(None, None, 'Fake error')
         self.assertEqual(True, bool(report))
         # True if any warnings
         report = sbol3.ValidationReport()
-        report.addWarning(None, 'Fake warning')
+        report.addWarning(None, None, 'Fake warning')
         self.assertEqual(True, bool(report))
         # True if both errors and warnings
         report = sbol3.ValidationReport()
-        report.addError(None, 'Fake error')
-        report.addWarning(None, 'Fake warning')
+        report.addError(None, None, 'Fake error')
+        report.addWarning(None, None, 'Fake warning')
         self.assertEqual(True, bool(report))
 
     def test_length(self):
         # Length should be the sum of errors and warnings
         report = sbol3.ValidationReport()
         self.assertEqual(0, len(report))
-        report.addError(None, 'Fake error')
+        report.addError(None, None, 'Fake error')
         self.assertEqual(1, len(report))
-        report.addWarning(None, 'Fake warning')
+        report.addWarning(None, None, 'Fake warning')
         self.assertEqual(2, len(report))
 
 

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -1,0 +1,36 @@
+import unittest
+
+import sbol3
+
+
+class TestValidationReport(unittest.TestCase):
+
+    def test_boolean(self):
+        # False if no errors or warnings
+        report = sbol3.ValidationReport()
+        self.assertEqual(False, bool(report))
+        # True if any errors
+        report.addError(None, 'Fake error')
+        self.assertEqual(True, bool(report))
+        # True if any warnings
+        report = sbol3.ValidationReport()
+        report.addWarning(None, 'Fake warning')
+        self.assertEqual(True, bool(report))
+        # True if both errors and warnings
+        report = sbol3.ValidationReport()
+        report.addError(None, 'Fake error')
+        report.addWarning(None, 'Fake warning')
+        self.assertEqual(True, bool(report))
+
+    def test_length(self):
+        # Length should be the sum of errors and warnings
+        report = sbol3.ValidationReport()
+        self.assertEqual(0, len(report))
+        report.addError(None, 'Fake error')
+        self.assertEqual(1, len(report))
+        report.addWarning(None, 'Fake warning')
+        self.assertEqual(2, len(report))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_varcomp.py
+++ b/test/test_varcomp.py
@@ -20,8 +20,10 @@ class TestVariableComponent(unittest.TestCase):
 
     def test_invalid_create(self):
         my_cardinality = 'https://github.com/synbiodex/pysbol3#someNumber'
-        with self.assertRaises(sbol3.ValidationError):
-            vc = sbol3.VariableFeature(cardinality=my_cardinality)
+        vf = sbol3.VariableFeature(cardinality=my_cardinality)
+        report = vf.validate()
+        self.assertIsNotNone(report)
+        self.assertEqual(1, len(report.errors))
 
     def test_round_trip1(self):
         # See https://github.com/SynBioDex/pySBOL3/issues/155

--- a/test/test_varcomp.py
+++ b/test/test_varcomp.py
@@ -64,9 +64,8 @@ class TestVariableComponent(unittest.TestCase):
         self.assertTrue(vf1.identity.startswith(cd1.identity))
         # Ensure that Measure m1 is valid. The bug tested here was that it
         # had been assigned an invalid displayId.
-        # Note: validate() currently returns None if an object is valid,
-        #       and raises an exception if the object is not valid.
-        self.assertIsNone(m1.validate())
+        report = m1.validate()
+        self.assertEqual(0, len(report.errors))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Change validation to generate a report instead of raising an exception. This allows multiple validation issues to be reported, rather than reporting only the first issue encountered.

This includes a validation method protocol, where all `validate` methods have the following signature and follow this rough pattern:

```python
def validate(self, report: ValidationReport = None) -> ValidationReport:
    report = super().validate(report)
    # Do validation here, calling `report.addError()` or `report.addWarning` as needed
    return report
```

A `ValidationReport` has accessors for a sequence of `ValidationError`, for violations of the SBOL specification, and sequence of `ValidationWarning` for violations of SBOL best practices. Validation handling code might do something along these lines (many other possibilities exist):

```python
report = thing.validate()
if report.errors:
    print(f'{len(report.errors)} validation errors were found:')
    for err in report.errors:
        print(f'\t{err.message}')
if report.warnings:
    print(f'{len(report.warnings)} validation warnings were found:')
    for warn in report.warnings:
        print(f'\t{warn.message}')
```

Closes #122 