### PR TITLE
Set document on child objects

### DIFF
--- a/sbol3/ownedobject.py
+++ b/sbol3/ownedobject.py
@@ -28,6 +28,9 @@ class OwnedObjectPropertyMixin:
         return self.property_owner._owned_objects
 
     def item_added(self, item: Any) -> None:
+        # First, set the document
+        if hasattr(item, 'document'):
+            item.document = self.property_owner.document
         if not self.property_owner.identity_is_url():
             return
         # if not item.display_id:

--- a/test/test_ownedobject.py
+++ b/test/test_ownedobject.py
@@ -123,6 +123,15 @@ class TestOwnedObject(unittest.TestCase):
         self.assertIsNone(lsc.document)
         c.features.append(lsc)
         self.assertIsNotNone(lsc.document)
+        interaction = sbol3.Interaction(sbol3.SBO_DEGRADATION)
+        c.interactions.append(interaction)
+        self.assertEqual(doc, interaction.document)
+        p = sbol3.Participation(sbol3.SBO_REACTANT, lsc)
+        interaction.participations.append(p)
+        self.assertEqual(doc, p.document)
+        resolved_lsc = p.participant.lookup()
+        self.assertEqual(lsc, resolved_lsc)
+        self.assertEqual(lsc.identity, resolved_lsc.identity)
 
     # TODO: Write tests for adding via a slice
     #       comp.constraints[0:1] = sbol3.Constraint('foo')

--- a/test/test_ownedobject.py
+++ b/test/test_ownedobject.py
@@ -112,6 +112,18 @@ class TestOwnedObject(unittest.TestCase):
             c.features = [sbol3.Range('https://example.com/fake', 1, 2)]
         self.assertEqual(c.features.type_constraint, sbol3.Feature)
 
+    def test_set_document(self):
+        # Ensure that document is set on child objects
+        # See https://github.com/SynBioDex/pySBOL3/issues/176
+        sbol3.set_namespace('https://bioprotocols.org/paml/primitives/')
+        doc = sbol3.Document()
+        c = sbol3.Component("scratch", sbol3.SBO_DNA)
+        doc.add(c)
+        lsc = sbol3.LocalSubComponent(sbol3.SBO_DNA)
+        self.assertIsNone(lsc.document)
+        c.features.append(lsc)
+        self.assertIsNotNone(lsc.document)
+
     # TODO: Write tests for adding via a slice
     #       comp.constraints[0:1] = sbol3.Constraint('foo')
 


### PR DESCRIPTION
When adding a child object, if the parent is in a document, give the
new child a pointer to the same document.

Fixes #176 