### PR TITLE
Make child objects error when re-parented

### DIFF
--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -92,6 +92,11 @@ class Identified(SBOLObject):
         parent object. SBOL compliant objects and URIs require updating
         whenever an owned object is added to a new parent.
         """
+        if self._identity is not None:
+            class_name = type(self).__name__
+            msg = f'{class_name} already has identity {self.identity}'
+            msg += ' and cannot be re-parented.'
+            raise ValueError(msg)
         self._identity = identity
         self._display_id = display_id
         # Now cycle through any owned objects and update their identities

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -35,16 +35,18 @@ class TestComponent(unittest.TestCase):
 
     def test_features(self):
         # See https://github.com/SynBioDex/pySBOL3/issues/149
+        # Note: this example was modified when fixing
+        #       https://github.com/SynBioDex/pySBOL3/issues/178
+        #       media_variable is unused in the original example so
+        #       it has been commented out here
 
-        media_template_uri = 'https://sd2e.org/media_template'
-        media_template = sbol3.LocalSubComponent(identity=media_template_uri,
-                                                 types=[sbol3.SBO_FUNCTIONAL_ENTITY])
+        media_template = sbol3.LocalSubComponent(types=[sbol3.SBO_FUNCTIONAL_ENTITY])
         media_template.name = 'media template'
 
-        variable_uri = 'https://github.com/synbiodex/pysbol3/variable'
-        media_variable = sbol3.VariableFeature(cardinality=sbol3.SBOL_ONE,
-                                               variable=media_template)
-        media_variable.variable = media_template
+        # variable_uri = 'https://github.com/synbiodex/pysbol3/variable'
+        # media_variable = sbol3.VariableFeature(cardinality=sbol3.SBOL_ONE,
+        #                                        variable=media_template)
+        # media_variable.variable = media_template
 
         all_sample_templates = [media_template]
         sample_template_uri = 'https://sd2e.org/measurement_template'


### PR DESCRIPTION
If a child object has a parent, and then is added to a new parent, raise
a ValueError. This prevents unseen issues from adding the same child
to multiple parents.

Fixes #178