### PR TITLE
Implement the visitor pattern

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -320,3 +320,42 @@ class Document:
         for obj in self.objects:
             obj.validate(report)
         return report
+
+    def find_all(self, predicate: Callable) -> List[Identified]:
+        """Executes a predicate on every object in the document tree,
+        gathering the list of objects to which the predicate returns true.
+        """
+        result: List[Identified] = []
+
+        def wrapped_filter(visited: Identified):
+            if predicate(visited):
+                result.append(visited)
+        self.accept(wrapped_filter)
+        return result
+
+    # TODO: Implement the visitor pattern allowing the user to specify
+    #       a function to direct the search, instead of only doing
+    #       depth-first search. For example, visit objects in provenance
+    #       order using Identified.derived_from.
+    # def accept_with_strategy(self, visitor: Callable, *, strategy: Callable = None):
+    #     # Use the strategy to compute the set of objects to visit
+    #     if strategy is None:
+    #         visit_list = self.objects
+    #     else:
+    #         visit_list = self.find_all(strategy)
+    #     while visit_list:
+    #         for obj in visit_list:
+    #             obj.accept(visitor)
+    #         # Compute the next set of objects to visit
+    #         if strategy is None:
+    #             visit_list = []
+    #         else:
+    #             visit_list = self.find_all(strategy)
+
+    def accept(self, visitor: Callable):
+        """Implement the visitor pattern by invoking `visitor` on all
+        top-level objects in the document. Those objects, in turn, will
+        invoke `visitor` on all of their child objects.
+        """
+        for obj in self.objects:
+            obj.accept(visitor)

--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -1,6 +1,6 @@
 import math
 import posixpath
-from typing import Union, List
+from typing import Union, List, Callable
 from urllib.parse import urlparse
 
 import rdflib
@@ -155,3 +155,12 @@ class Identified(SBOLObject):
             for item in items:
                 graph.add((identity, rdf_prop, rdflib.URIRef(item.identity)))
                 item.serialize(graph)
+
+    def accept(self, visitor: Callable):
+        """Implement the visitor pattern by invoking `visitor` on self
+        and all child objects.
+        """
+        visitor(self)
+        for object_list in self._owned_objects.values():
+            for obj in object_list:
+                obj.accept(visitor)

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -190,8 +190,56 @@ class TestDocument(unittest.TestCase):
         sf = sbol3.SequenceFeature([r])
         c1.features.append(sf)
         report = doc.validate()
-        # We should find the validation issue in the range
+        # We should find the validation issue in the Range
         self.assertEqual(1, len(report))
+
+    def test_find_all(self):
+        test_files = {
+            os.path.join(SBOL3_LOCATION, 'entity', 'model',
+                         'model.nt'): 2,
+            os.path.join(SBOL3_LOCATION, 'multicellular',
+                         'multicellular.nt'): 77,
+        }
+        for file, count in test_files.items():
+            doc = sbol3.Document()
+            doc.read(file)
+            found = doc.find_all(lambda _: True)
+            self.assertEqual(count, len(found))
+
+    def test_find_all2(self):
+        file = os.path.join(SBOL3_LOCATION, 'multicellular',
+                            'multicellular.nt')
+        doc = sbol3.Document()
+        doc.read(file)
+        # Find all instances of Participation
+        found = doc.find_all(lambda obj: isinstance(obj, sbol3.Participation))
+        self.assertEqual(11, len(found))
+
+    def test_visit_all(self):
+        visited_list = []
+
+        def my_visitor(obj: sbol3.Identified):
+            visited_list.append(obj)
+        file = os.path.join(SBOL3_LOCATION, 'multicellular',
+                            'multicellular.nt')
+        doc = sbol3.Document()
+        doc.read(file)
+        doc.accept(my_visitor)
+        self.assertEqual(77, len(visited_list))
+
+    def test_visit_participations(self):
+        # Visit all and only the participations
+        visited_list = []
+
+        def my_visitor(obj: sbol3.Identified):
+            if isinstance(obj, sbol3.Participation):
+                visited_list.append(obj)
+        file = os.path.join(SBOL3_LOCATION, 'multicellular',
+                            'multicellular.nt')
+        doc = sbol3.Document()
+        doc.read(file)
+        doc.accept(my_visitor)
+        self.assertEqual(11, len(visited_list))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Allow the user to specify a function that will be invoked on every
object in the document. Also available to call on any object to
have a function run on an object and all of its children.

Fixes #169 