### PR TITLE
Do not add referenced objects to the document

### DIFF
--- a/sbol3/refobj_property.py
+++ b/sbol3/refobj_property.py
@@ -60,7 +60,8 @@ class ReferencedObjectSingleton(ReferencedObjectMixin, SingletonProperty):
 
     def set(self, value: Any) -> None:
         super().set(value)
-        self.maybe_add_to_document(value)
+        # See bug 184 - don't add to document
+        # self.maybe_add_to_document(value)
 
 
 class ReferencedObjectList(ReferencedObjectMixin, ListProperty):
@@ -74,8 +75,9 @@ class ReferencedObjectList(ReferencedObjectMixin, ListProperty):
         if initial_value:
             self.set(initial_value)
 
-    def item_added(self, item: Any) -> None:
-        self.maybe_add_to_document(item)
+    # See bug 184 - don't add to document
+    # def item_added(self, item: Any) -> None:
+    #     self.maybe_add_to_document(item)
 
 
 def ReferencedObject(property_owner: Any, property_uri: str,

--- a/test/test_referenced_object.py
+++ b/test/test_referenced_object.py
@@ -63,6 +63,7 @@ class TestReferencedObject(unittest.TestCase):
         component = sbol3.Component('c1', sbol3.SBO_DNA)
         sequence = sbol3.Sequence('seq1')
         doc.add(component)
+        doc.add(sequence)
         component.sequences.append(sequence)
         seq2_uri = component.sequences[0]
         self.assertEqual(sequence.identity, seq2_uri)
@@ -78,6 +79,7 @@ class TestReferencedObject(unittest.TestCase):
         component = sbol3.Component('c1', sbol3.SBO_DNA)
         sequence = sbol3.Sequence('seq1')
         doc.add(component)
+        doc.add(sequence)
         component.sequences = [sequence]
         seq2_uri = component.sequences[0]
         self.assertEqual(sequence.identity, seq2_uri)
@@ -93,12 +95,35 @@ class TestReferencedObject(unittest.TestCase):
         test_parent = SingleRefObj('sro1')
         sequence = sbol3.Sequence('seq1')
         doc.add(test_parent)
+        doc.add(sequence)
         test_parent.sequence = sequence
         seq2_uri = test_parent.sequence
         self.assertEqual(sequence.identity, seq2_uri)
         seq = seq2_uri.lookup()
         self.assertIsNotNone(seq)
         self.assertEqual(sequence, seq)
+
+    def test_adding_referenced_objects(self):
+        # Verify that sbol3 does not try to add objects
+        # to the document when they are added to a referenced
+        # object property.
+        #
+        # See https://github.com/SynBioDex/pySBOL3/issues/184
+        doc = sbol3.Document()
+        sbol3.set_namespace('https://example.org')
+        execution = sbol3.Activity('protocol_execution')
+        doc.add(execution)
+        foo = sbol3.Collection('http://example.org/baz')
+        foo.members.append(execution)
+        # Verify that foo did not get document assigned
+        self.assertIsNone(foo.document)
+        # Now explicitly add foo to the document and ensure
+        # everything works as expected
+        doc.add(foo)
+        self.assertEqual(execution.identity, foo.members[0])
+        # Also verify that we can use lookup on the object
+        # to get back to the original instance via document lookup
+        self.assertEqual(execution.identity, foo.members[0].lookup().identity)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The user must add referenced objects to the document themselves.
This avoid an issue where sbol3 tries to add an object to the
document again, which causes an error.

Fixes #184 