### PR TITLE
Add TopLevel.clone()

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -352,7 +352,7 @@ class Document:
     #         else:
     #             visit_list = self.find_all(strategy)
 
-    def accept(self, visitor: Callable):
+    def accept(self, visitor: Callable[[Identified], None]):
         """Implement the visitor pattern by invoking `visitor` on all
         top-level objects in the document. Those objects, in turn, will
         invoke `visitor` on all of their child objects.

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -212,7 +212,12 @@ class Document:
             message += ' already exists in document'
             raise ValueError(message)
         self.objects.append(obj)
-        obj.document = self
+
+        # Assign this document to the object tree rooted
+        # in the TopLevel being added
+        def assign_document(x: Identified):
+            x.document = self
+        obj.accept(assign_document)
 
     def _find_in_objects(self, search_string: str) -> Optional[Identified]:
         # TODO: implement recursive search
@@ -321,7 +326,7 @@ class Document:
             obj.validate(report)
         return report
 
-    def find_all(self, predicate: Callable) -> List[Identified]:
+    def find_all(self, predicate: Callable[[Identified], bool]) -> List[Identified]:
         """Executes a predicate on every object in the document tree,
         gathering the list of objects to which the predicate returns true.
         """

--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -165,7 +165,7 @@ class Identified(SBOLObject):
                 graph.add((identity, rdf_prop, rdflib.URIRef(item.identity)))
                 item.serialize(graph)
 
-    def accept(self, visitor: Callable):
+    def accept(self, visitor: Callable[['Identified'], None]):
         """Implement the visitor pattern by invoking `visitor` on self
         and all child objects.
         """

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -92,7 +92,6 @@ class TestComponent(unittest.TestCase):
                          c2.identity)
         self.assertListEqual(list(c1.sequences), list(c2.sequences))
 
-    @unittest.expectedFailure
     def test_cloning_with_children(self):
         # This test does not use `sbol3.set_namespace` as the other
         # cloning unit tests do. This is on purpose to verify that
@@ -119,6 +118,7 @@ class TestComponent(unittest.TestCase):
         self.assertIsInstance(sc2, sbol3.SubComponent)
         self.assertNotEqual(sc1.identity, sc2.identity)
         self.assertTrue(sc2.identity.startswith(c2.identity))
+        # Ensure that the reference was updated properly
         self.assertEqual(c2.identity, sc2.instance_of)
         self.assertIsNone(sc2.document)
         es2 = sc2.source_locations[0]


### PR DESCRIPTION
Add ability to clone a TopLevel. Ensure that child objects are properly re-parented and updated with compliant identities. Ensure that the resulting clone has no Document pointer. If a user wants the clone added to a Document they must do so themselves.

Fixes #131 