### PR TITLE
Update the Sequence encoding constants

### DIFF
--- a/sbol3/constants.py
+++ b/sbol3/constants.py
@@ -106,10 +106,11 @@ SBOL_VARIANT_DERIVATION = SBOL3_NS + 'variantDerivation'
 SBOL_VARIANT_MEASURE = SBOL3_NS + 'variantMeasure'
 
 # Recommended values for Sequence encoding
-SBOL_IUPAC_DNA = SBOL3_NS + 'iupacNucleicAcid'
-SBOL_IUPAC_RNA = SBOL_IUPAC_DNA
-SBOL_IUPAC_PROTEIN = SBOL3_NS + 'iupacAminoAcid'
-SMILES_ENCODING = 'http://www.opensmiles.org/opensmiles.html'
+IUPAC_DNA_ENCODING = 'https://identifiers.org/edam:format_1207'
+IUPAC_RNA_ENCODING = 'https://identifiers.org/edam:format_1207'
+IUPAC_PROTEIN_ENCODING = 'https://identifiers.org/edam:format_1208'
+INCHI_ENCODING = 'https://identifiers.org/edam:format_1197'
+SMILES_ENCODING = 'https://identifiers.org/edam:format_1196'
 
 # Valid values for Feature orientation
 # See SBOL3 Section 6.4.1 Table 5

--- a/sbol3/sequence.py
+++ b/sbol3/sequence.py
@@ -27,6 +27,14 @@ class Sequence(TopLevel):
         if self.elements and not self.encoding:
             message = 'Sequence encoding is required if elements are set'
             report.addError(self.identity, None, message)
+        # Check that the encoding is part of the recommended set
+        encodings = {
+            IUPAC_DNA_ENCODING, IUPAC_RNA_ENCODING, IUPAC_PROTEIN_ENCODING,
+            INCHI_ENCODING, SMILES_ENCODING
+        }
+        if self.encoding and self.encoding not in encodings:
+            message = 'Sequence encoding is not in the recommended set'
+            report.addWarning(self.identity, 'sbol3-10505', message)
         return report
 
 

--- a/test/test_sequence.py
+++ b/test/test_sequence.py
@@ -36,14 +36,15 @@ class TestSequence(unittest.TestCase):
         seq = sbol3.Sequence(display_id)
         self.assertIsNotNone(seq)
         seq.elements = 'actg'
-        seq.encoding = sbol3.SBOL_IUPAC_DNA
+        seq.encoding = sbol3.IUPAC_DNA_ENCODING
         # Should not raise a ValidationError
-        seq.validate()
+        report = seq.validate()
+        self.assertEqual(0, len(report))
 
     def test_full_constructor(self):
         identity = 'https://github.com/synbiodex/pysbol3/s1'
         elements = 'GCAT'
-        encoding = sbol3.SBOL_IUPAC_DNA
+        encoding = sbol3.IUPAC_DNA_ENCODING
         attachments = ['https://github.com/synbiodex/pysbol3/attachment1']
         name = None
         description = None
@@ -69,6 +70,21 @@ class TestSequence(unittest.TestCase):
         self.assertEqual(derived_from, s1.derived_from)
         self.assertEqual(generated_by, s1.generated_by)
         self.assertEqual(measures, s1.measures)
+
+    def test_invalid_encoding(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
+        display_id = 'seq1'
+        seq = sbol3.Sequence(display_id)
+        self.assertIsNotNone(seq)
+        seq.elements = 'actg'
+        # This is an encoding from SBOL 3.0. It is no longer
+        # valid as of 3.0.1/3.1.
+        seq.encoding = 'http://sbols.org/v3#iupacNucleicAcid'
+        # We expect 1 warning for the encoding that is not in the
+        # recommended set.
+        report = seq.validate()
+        self.assertEqual(1, len(report))
+        self.assertEqual(1, len(report.warnings))
 
 
 if __name__ == '__main__':

--- a/test/test_style.py
+++ b/test/test_style.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 import sys
 import unittest
 


### PR DESCRIPTION
The Sequence encoding constants changed in SBOL3 3.0.1. Update to the new
constants. Also add a validation warning if the sequence encoding is not
in the recommended set.

Fixes #185 