### PR TITLE
Make Document.write_string return a string

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -261,7 +261,7 @@ class Document:
             result = graph.serialize(format=file_format, context=context)
         else:
             result = graph.serialize(format=file_format)
-        return result
+        return result.decode()
 
     def write(self, fpath: str, file_format: str = None) -> None:
         """Write the document to file.
@@ -274,7 +274,7 @@ class Document:
             file_format = self._guess_format(fpath)
         if file_format is None:
             raise ValueError('Unable to determine file format')
-        with open(fpath, 'wb') as outfile:
+        with open(fpath, 'w') as outfile:
             outfile.write(self.write_string(file_format))
 
     def graph(self) -> rdflib.Graph:

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -169,7 +169,7 @@ class TestDocument(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdirname:
             test_file = os.path.join(tmpdirname, filename)
             doc.write(test_file, sbol3.SORTED_NTRIPLES)
-            with open(test_file, 'rb') as infile:
+            with open(test_file, 'r') as infile:
                 expected = infile.read()
         actual = doc.write_string(sbol3.SORTED_NTRIPLES)
         self.assertEqual(expected, actual)


### PR DESCRIPTION
Make Document.write_string agree with its declaration by returning a
string instead of returning bytes.

Fixes #200 