### PR TITLE
Fix initial value checking on all properties

### DIFF
--- a/sbol3/boolean_property.py
+++ b/sbol3/boolean_property.py
@@ -38,7 +38,7 @@ class BooleanListProperty(BooleanPropertyMixin, ListProperty):
                  initial_value: Optional[List[bool]] = None):
         super().__init__(property_owner, property_uri,
                          lower_bound, upper_bound, validation_rules)
-        if initial_value:
+        if initial_value is not None:
             self.set(initial_value)
 
 

--- a/sbol3/int_property.py
+++ b/sbol3/int_property.py
@@ -38,7 +38,7 @@ class IntListProperty(IntPropertyMixin, ListProperty):
                  initial_value: Optional[List[int]] = None):
         super().__init__(property_owner, property_uri,
                          lower_bound, upper_bound, validation_rules)
-        if initial_value:
+        if initial_value is not None:
             self.set(initial_value)
 
 

--- a/sbol3/om_unit.py
+++ b/sbol3/om_unit.py
@@ -95,7 +95,7 @@ class SingularUnit(Unit):
     """
 
     def __init__(self, identity: str, symbol: str, label: str,
-                 *, unit: str = None, factor: str = None,
+                 *, unit: str = None, factor: float = None,
                  alternative_symbols: List[str] = None,
                  alternative_labels: List[str] = None,
                  comment: str = None,

--- a/sbol3/ownedobject.py
+++ b/sbol3/ownedobject.py
@@ -71,7 +71,7 @@ class OwnedObjectSingletonProperty(OwnedObjectPropertyMixin, SingletonProperty):
         # methods are not set up properly for that. They would need
         # to accept unknown keyword arguments.
         self.type_constraint = type_constraint
-        if initial_value:
+        if initial_value is not None:
             self.set(initial_value)
 
     def validate(self, name: str, report: ValidationReport):
@@ -97,7 +97,7 @@ class OwnedObjectListProperty(OwnedObjectPropertyMixin, ListProperty):
         # methods are not set up properly for that. They would need
         # to accept unknown keyword arguments.
         self.type_constraint = type_constraint
-        if initial_value:
+        if initial_value is not None:
             self.set(initial_value)
 
     def validate(self, name: str, report: ValidationReport):

--- a/sbol3/refobj_property.py
+++ b/sbol3/refobj_property.py
@@ -55,7 +55,7 @@ class ReferencedObjectSingleton(ReferencedObjectMixin, SingletonProperty):
                  initial_value: Optional[str] = None):
         super().__init__(property_owner, property_uri,
                          lower_bound, upper_bound, validation_rules)
-        if initial_value:
+        if initial_value is not None:
             self.set(initial_value)
 
     def set(self, value: Any) -> None:
@@ -72,7 +72,7 @@ class ReferencedObjectList(ReferencedObjectMixin, ListProperty):
                  initial_value: Optional[str] = None):
         super().__init__(property_owner, property_uri,
                          lower_bound, upper_bound, validation_rules)
-        if initial_value:
+        if initial_value is not None:
             self.set(initial_value)
 
     # See bug 184 - don't add to document

--- a/sbol3/text_property.py
+++ b/sbol3/text_property.py
@@ -26,7 +26,10 @@ class TextSingletonProperty(TextPropertyMixin, SingletonProperty):
                  initial_value: Optional[str] = None):
         super().__init__(property_owner, property_uri,
                          lower_bound, upper_bound, validation_rules)
-        if initial_value:
+        # See https://github.com/SynBioDex/pySBOL3/issues/208
+        # The empty string is boolean False, so explicitly check for None
+        # so that we don't discard an empty string as an initial value
+        if initial_value is not None:
             self.set(initial_value)
 
 
@@ -38,7 +41,7 @@ class TextListProperty(TextPropertyMixin, ListProperty):
                  initial_value: Optional[str] = None):
         super().__init__(property_owner, property_uri,
                          lower_bound, upper_bound, validation_rules)
-        if initial_value:
+        if initial_value is not None:
             self.set(initial_value)
 
 

--- a/sbol3/uri_property.py
+++ b/sbol3/uri_property.py
@@ -26,7 +26,7 @@ class URISingletonProperty(URIPropertyMixin, SingletonProperty):
                  initial_value: Optional[str] = None):
         super().__init__(property_owner, property_uri,
                          lower_bound, upper_bound, validation_rules)
-        if initial_value:
+        if initial_value is not None:
             self.set(initial_value)
 
 
@@ -38,7 +38,7 @@ class URIListProperty(URIPropertyMixin, ListProperty):
                  initial_value: Optional[str] = None):
         super().__init__(property_owner, property_uri,
                          lower_bound, upper_bound, validation_rules)
-        if initial_value:
+        if initial_value is not None:
             self.set(initial_value)
 
 

--- a/test/test_om_unit.py
+++ b/test/test_om_unit.py
@@ -132,6 +132,30 @@ class TestSingularUnit(unittest.TestCase):
         self.assertIsNotNone(sunit.description)
         self.assertEqual('litre', sunit.display_id)
 
+    def test_initial_value(self):
+        # See https://github.com/SynBioDex/pySBOL3/issues/208
+        # Use `alt_symbols` to test setting with the empty string.
+        # This isn't the actual bug reported in #208. It is a possibly
+        # related issue, so we add a unit test just in case.
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
+        display_id = 'litre'
+        symbol = display_id
+        label = display_id
+        unit = 'https://sbolstandard.org/examples/litre'
+        factor = 0.001
+        alt_symbols = ['']
+        sunit = sbol3.SingularUnit(display_id, symbol, label,
+                                   alternative_symbols=alt_symbols,
+                                   unit=unit,
+                                   factor=factor)
+        self.assertIsNotNone(sunit)
+        self.assertIsInstance(sunit, sbol3.SingularUnit)
+        self.assertEqual(factor, sunit.factor)
+        self.assertEqual(unit, sunit.unit)
+        self.assertEqual(symbol, sunit.symbol)
+        self.assertEqual(label, sunit.label)
+        self.assertCountEqual(alt_symbols, sunit.alternative_symbols)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_sequence.py
+++ b/test/test_sequence.py
@@ -86,6 +86,17 @@ class TestSequence(unittest.TestCase):
         self.assertEqual(1, len(report))
         self.assertEqual(1, len(report.warnings))
 
+    def test_initial_value(self):
+        # See https://github.com/SynBioDex/pySBOL3/issues/208
+        identity = 'https://github.com/synbiodex/pysbol3/s1'
+        elements = ''
+        # encoding = sbol3.IUPAC_DNA_ENCODING
+        s1 = sbol3.Sequence(identity=identity,
+                            elements=elements)
+        self.assertEqual(identity, s1.identity)
+        self.assertEqual(elements, s1.elements)
+        # self.assertEqual(encoding, s1.encoding)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_subcomponent.py
+++ b/test/test_subcomponent.py
@@ -22,7 +22,7 @@ class TestSubComponent(unittest.TestCase):
 
     def test_invalid_create(self):
         # SubComponent requires an `instance_of` argument
-        sc = sbol3.SubComponent('')
+        sc = sbol3.SubComponent(None)
         report = sc.validate()
         self.assertIsNotNone(report)
         self.assertEqual(1, len(report.errors))


### PR DESCRIPTION
When testing whether an initial value is specified, use `if initial_value is not None` instead of relying on boolean conversion using  `if initial_value`. `0`, `0.0` and `''` all convert to False so these initial values were being ignored.

Fixes #208