### PR TITLE
Handle non-SBOL RDF in SBOL files

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -91,6 +91,9 @@ class Document:
         for identity, types in identity_types.items():
             if len(types) == 1:
                 type_uri = types[0]
+                if not type_uri.startswith(SBOL3_NS):
+                    # Skip non-SBOL objects
+                    continue
                 try:
                     builder = self._uri_type_map[type_uri]
                 except KeyError:
@@ -114,7 +117,11 @@ class Document:
                 continue
             str_s = str(s)
             str_p = str(p)
-            obj = objects[str_s]
+            try:
+                obj = objects[str_s]
+            except KeyError:
+                # Object is not an SBOL object, skip it
+                continue
             if str_p in obj._owned_objects:
                 other_identity = str(o)
                 other = objects[other_identity]

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -39,41 +39,71 @@ class Document:
     def __init__(self):
         self.logger = logging.getLogger(SBOL_LOGGER_NAME)
         self.objects: List[Identified] = []
+        # Orphans are non-TopLevel objects that are not otherwise linked
+        # into the object hierarchy.
         self.orphans: List[Identified] = []
         self._namespaces: Dict[str, str] = _default_bindings.copy()
+        # Non-SBOL triples. These are triples that are not recognized as
+        # SBOL. They are stored in _other_rdf for round-tripping purposes.
+        self._other_rdf = rdflib.Graph()
 
-    def _make_custom_object(self, identity: str, types: List[str]) -> Identified:
-        if SBOL_IDENTIFIED in types:
-            types.remove(SBOL_IDENTIFIED)
+    def _build_extension_object(self, identity: str, sbol_type: str,
+                                types: List[str]) -> Optional[Identified]:
+        custom_types = {
+            SBOL_IDENTIFIED: CustomIdentified,
+            SBOL_TOP_LEVEL: CustomTopLevel
+        }
+        if sbol_type not in custom_types:
+            msg = f'{identity} has SBOL type {sbol_type} which is not one of'
+            msg += f' {custom_types.keys()}. (See Section 6.11)'
+            raise SBOLError(msg)
+        # Section 6.11 implies that an extension object MUST have one
+        # type outside the SBOL3 namespace
+        if len(types) > 1:
+            msg = f'{identity} has more than one rdfType property outside the'
+            msg += f' {SBOL3_NS} namespace. (See Section 6.11)'
+            raise SBOLError(msg)
+        build_type = types[0]
+        try:
+            builder = self._uri_type_map[build_type]
+        except KeyError:
+            logging.warning(f'No builder found for {build_type}')
+            builder = custom_types[sbol_type]
+        return builder(identity=identity, type_uri=build_type)
+
+    def _build_object(self, identity: str, types: List[str]) -> Optional[Identified]:
+        # Given an identity and a list of RDF types, build an object if possible.
+        # If there is 1 SBOL type and we don't know it, raise an exception
+        # If there are multiple types and 1 is TopLevel or Identified, then
+        #    it is an extension. Use the other types to try to build it. If
+        #    no other type is known, build a generic TopLevel or Identified.
+        sbol_types = [t for t in types if t.startswith(SBOL3_NS)]
+        if len(sbol_types) == 0:
+            # If there are no SBOL types in the list, do not build
+            return None
+        if len(sbol_types) > 1:
+            # If there are multiple SBOL types in the list, raise an error.
+            # SBOL 3.0.1 Section 5.4: "an object MUST have no more than one
+            # rdfType property in the 'http://sbols.org/v3#' namespace"
+            msg = f'{identity} has more than one rdfType property in the'
+            msg += f' {SBOL3_NS} namespace.'
+            raise SBOLError(msg)
+        if len(types) == 1:
+            # Simple case: the one SBOL type is the only type.
+            type_uri = types[0]
             try:
-                other_type = types[0]
-            except IndexError:
-                raise SBOLError('Custom object has only one RDF type')
-            if other_type.startswith(SBOL3_NS):
-                raise SBOLError('Secondary type may not be in SBOL3 namespace')
-            try:
-                builder = self._uri_type_map[other_type]
+                builder = self._uri_type_map[type_uri]
             except KeyError:
-                logging.warning(f'No builder found for {other_type}')
-                builder = CustomIdentified
-            return builder(identity=identity, type_uri=other_type)
-        elif SBOL_TOP_LEVEL in types:
-            types.remove(SBOL_TOP_LEVEL)
-            try:
-                other_type = types[0]
-            except IndexError:
-                raise SBOLError('Custom object has only one RDF type')
-            if other_type.startswith(SBOL3_NS):
-                raise SBOLError('Secondary type may not be in SBOL3 namespace')
-            try:
-                builder = self._uri_type_map[other_type]
-            except KeyError:
-                logging.warning(f'No builder found for {other_type}')
-                builder = CustomTopLevel
-            return builder(identity=identity, type_uri=other_type)
+                logging.warning(f'No builder found for {type_uri}')
+                raise SBOLError(f'Unknown type {type_uri}')
+            obj = builder(identity=identity, type_uri=type_uri)
+            return obj
         else:
-            message = 'Custom types must contain either Identified or TopLevel'
-            raise SBOLError(message)
+            # If there is more than 1 rdf type, it must be an
+            # extension.
+            sbol_type = sbol_types[0]
+            types.remove(sbol_type)
+            return self._build_extension_object(identity, sbol_type, types)
 
     def _parse_objects(self, graph: rdflib.Graph) -> Dict[str, SBOLObject]:
         # First extract the identities and their types. Each identity
@@ -89,24 +119,10 @@ class Document:
         # Now iterate over the identity->type dict creating the objects.
         result = {}
         for identity, types in identity_types.items():
-            if len(types) == 1:
-                type_uri = types[0]
-                if not type_uri.startswith(SBOL3_NS):
-                    # Skip non-SBOL objects
-                    continue
-                try:
-                    builder = self._uri_type_map[type_uri]
-                except KeyError:
-                    logging.warning(f'No builder found for {type_uri}')
-                    raise SBOLError(f'Unknown type {type_uri}')
-                obj = builder(identity=identity, type_uri=type_uri)
-            elif len(types) == 2:
-                obj = self._make_custom_object(identity, types)
-            else:
-                message = f'Expected either 1 or 2 types for {identity}'
-                raise SBOLError(message)
-            obj.document = self
-            result[obj.identity] = obj
+            obj = self._build_object(identity, types)
+            if obj:
+                obj.document = self
+                result[obj.identity] = obj
         return result
 
     @staticmethod
@@ -182,6 +198,13 @@ class Document:
         # Store the namespaces in the Document for later use
         for prefix, uri in graph.namespaces():
             self.bind(prefix, uri)
+        # Remove the triples for every object we have loaded, leaving
+        # the non-RDF triples for round tripping
+        # See https://github.com/SynBioDex/pySBOL3/issues/96
+        for uri in objects:
+            graph.remove((uri, None, None))
+        # Now tuck away the graph for use in Document.write_string()
+        self._other_rdf = graph
 
     def _guess_format(self, fpath: str):
         return rdflib.util.guess_format(fpath)
@@ -297,6 +320,8 @@ class Document:
             orphan.serialize(graph)
         for obj in self.objects:
             obj.serialize(graph)
+        # Add the non-SBOL RDF triples into the generated graph
+        graph += self._other_rdf
         return graph
 
     def bind(self, prefix: str, uri: str) -> None:

--- a/test/resources/mixed-rdf.nt
+++ b/test/resources/mixed-rdf.nt
@@ -1,0 +1,6 @@
+<http://example.com/foaf/pparker> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
+<http://example.com/foaf/pparker> <http://xmlns.com/foaf/0.1/mbox> <mailto:peter.parker@dailybugle.com> .
+<http://example.com/foaf/pparker> <http://xmlns.com/foaf/0.1/name> "Peter Parker" .
+<http://example.com/sbol3/c1> <http://sbols.org/v3#displayId> "c1" .
+<http://example.com/sbol3/c1> <http://sbols.org/v3#type> <https://identifiers.org/SBO:0000251> .
+<http://example.com/sbol3/c1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Component> .

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -9,7 +9,6 @@ import sbol3
 
 MODULE_LOCATION = os.path.dirname(os.path.abspath(__file__))
 SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
-TEST_RESOURCE_DIR = os.path.join(MODULE_LOCATION, 'resources')
 
 
 class TestDocument(unittest.TestCase):
@@ -253,15 +252,6 @@ class TestDocument(unittest.TestCase):
             doc.builder('http://example.com/SomeType')
         with self.assertRaises(ValueError):
             doc.builder(None)
-
-    def test_mixed_rdf(self):
-        # Test loading a file that contains both SBOL and non-SBOL
-        test_file = os.path.join(TEST_RESOURCE_DIR, 'mixed-rdf.nt')
-        doc = sbol3.Document()
-        doc.read(test_file)
-        out_file = os.path.join(os.path.dirname(MODULE_LOCATION),
-                                'tmp', 'mixed-rdf.nt')
-        doc.write(out_file)
 
 
 if __name__ == '__main__':

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -9,6 +9,7 @@ import sbol3
 
 MODULE_LOCATION = os.path.dirname(os.path.abspath(__file__))
 SBOL3_LOCATION = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL3')
+TEST_RESOURCE_DIR = os.path.join(MODULE_LOCATION, 'resources')
 
 
 class TestDocument(unittest.TestCase):
@@ -252,6 +253,15 @@ class TestDocument(unittest.TestCase):
             doc.builder('http://example.com/SomeType')
         with self.assertRaises(ValueError):
             doc.builder(None)
+
+    def test_mixed_rdf(self):
+        # Test loading a file that contains both SBOL and non-SBOL
+        test_file = os.path.join(TEST_RESOURCE_DIR, 'mixed-rdf.nt')
+        doc = sbol3.Document()
+        doc.read(test_file)
+        out_file = os.path.join(os.path.dirname(MODULE_LOCATION),
+                                'tmp', 'mixed-rdf.nt')
+        doc.write(out_file)
 
 
 if __name__ == '__main__':

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -12,6 +12,7 @@ import sbol3
 MODULE_LOCATION = os.path.dirname(os.path.abspath(__file__))
 SBOL_TEST_SUITE = os.path.join(MODULE_LOCATION, 'SBOLTestSuite')
 SBOL3_LOCATION = os.path.join(SBOL_TEST_SUITE, 'SBOL3')
+TEST_RESOURCE_DIR = os.path.join(MODULE_LOCATION, 'resources')
 
 DEBUG_ENV_VAR = 'SBOL_TEST_DEBUG'
 
@@ -153,6 +154,11 @@ class TestRoundTrip(unittest.TestCase):
                 self.setUp()
                 self.run_round_trip_file(test_file, file_format)
                 self.tearDown()
+
+    def test_mixed_rdf(self):
+        # See https://github.com/SynBioDex/pySBOL3/issues/96
+        test_file = os.path.join(TEST_RESOURCE_DIR, 'mixed-rdf.nt')
+        self.run_round_trip_file(test_file, sbol3.NTRIPLES)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Successfully round trip files that include non-SBOL RDF triples. Include a test case in the round trip testing.

Fixes #96 