### PR TITLE
Store multiple RDF types

### DIFF
--- a/sbol3/constants.py
+++ b/sbol3/constants.py
@@ -14,6 +14,9 @@ SBOL3_NS = 'http://sbols.org/v3#'
 SBOL2_NS = 'http://sbols.org/v2#'
 SBOL1_NS = 'http://sbols.org/v1#'
 
+# RDF
+RDF_NS = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+
 # Provenance
 PROV_NS = 'http://www.w3.org/ns/prov#'
 
@@ -25,6 +28,11 @@ SO_NS = "https://identifiers.org/SO:"
 
 # Namespace for Systems Biology Ontology (SBO) terms
 SBO_NS = 'https://identifiers.org/SBO:'
+
+# ----------
+# RDF terms
+# ----------
+RDF_TYPE = RDF_NS + 'type'
 
 # ----------
 # SBOL 3 terms

--- a/sbol3/custom.py
+++ b/sbol3/custom.py
@@ -18,13 +18,12 @@ class CustomIdentified(Identified):
                          name=name, description=description,
                          derived_from=derived_from, generated_by=generated_by,
                          measures=measures)
-        self.rdf_type = URIProperty(self, rdflib.RDF.type, 1, 1,
-                                    initial_value=sbol_type_uri)
+        self._rdf_types.append(sbol_type_uri)
 
     def validate(self, report: ValidationReport = None) -> ValidationReport:
         report = super().validate(report)
-        if self.rdf_type is None:
-            message = 'rdf_type is a required property of CustomIdentified'
+        if len(self._rdf_types) < 2:
+            message = 'Extension classes must have at least 2 rdf:type properties'
             report.addError(self.identity, None, message)
         return report
 
@@ -42,12 +41,11 @@ class CustomTopLevel(TopLevel):
                          attachments=attachments, name=name,
                          description=description, derived_from=derived_from,
                          generated_by=generated_by, measures=measures)
-        self.rdf_type = URIProperty(self, rdflib.RDF.type, 1, 1,
-                                    initial_value=sbol_type_uri)
+        self._rdf_types.append(sbol_type_uri)
 
     def validate(self, report: ValidationReport = None) -> ValidationReport:
         report = super().validate(report)
-        if self.rdf_type is None:
-            message = 'rdf_type is a required property of CustomTopLevel'
+        if len(self._rdf_types) < 2:
+            message = 'Extension classes must have at least 2 rdf:type properties'
             report.addError(self.identity, None, message)
         return report

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -128,9 +128,6 @@ class Document:
     @staticmethod
     def _parse_attributes(objects, graph):
         for s, p, o in graph.triples((None, None, None)):
-            if p == rdflib.RDF.type:
-                # RDF.types have been processed already
-                continue
             str_s = str(s)
             str_p = str(p)
             try:

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -144,6 +144,13 @@ class Document:
                 other_identity = str(o)
                 other = objects[other_identity]
                 obj._owned_objects[str_p].append(other)
+            elif str_p == RDF_TYPE:
+                # Handle rdf:type specially because the main type(s)
+                # will already be in the list from the build_object
+                # phase and those entries need to be maintained and
+                # we don't want duplicates
+                if o not in obj._properties[str_p]:
+                    obj._properties[str_p].append(o)
             else:
                 obj._properties[str_p].append(o)
 

--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -22,7 +22,7 @@ class Identified(SBOLObject):
                  *, name: str = None, description: str = None,
                  derived_from: List[str] = None, generated_by: List[str] = None,
                  measures: List[SBOLObject] = None) -> None:
-        super().__init__(identity, type_uri)
+        super().__init__(identity)
         self._display_id = TextProperty(self, SBOL_DISPLAY_ID, 0, 1)
         self.name = TextProperty(self, SBOL_NAME, 0, 1, initial_value=name)
         self.description = TextProperty(self, SBOL_DESCRIPTION, 0, 1,
@@ -40,6 +40,8 @@ class Identified(SBOLObject):
                                     type_constraint=Identified)
         # Identity has been set by the SBOLObject constructor
         self._display_id = self._extract_display_id(self.identity)
+        self._rdf_types = URIProperty(self, rdflib.RDF.type, 1, math.inf,
+                                      initial_value=[type_uri])
 
     @staticmethod
     def _is_valid_display_id(display_id: str) -> bool:
@@ -74,6 +76,10 @@ class Identified(SBOLObject):
             msg += ' A displayId MUST be composed of only alphanumeric'
             msg += ' or underscore characters and MUST NOT begin with a digit.'
             raise ValueError(msg)
+
+    @property
+    def type_uri(self):
+        return self._rdf_types[0]
 
     def _validate_display_id(self, report: ValidationReport) -> None:
         if self.identity_is_url():
@@ -169,7 +175,7 @@ class Identified(SBOLObject):
 
     def serialize(self, graph: rdflib.Graph):
         identity = rdflib.URIRef(self.identity)
-        graph.add((identity, rdflib.RDF.type, rdflib.URIRef(self.type_uri)))
+        # graph.add((identity, rdflib.RDF.type, rdflib.URIRef(self.type_uri)))
         for prop, items in self._properties.items():
             if not items:
                 continue

--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -40,7 +40,7 @@ class Identified(SBOLObject):
                                     type_constraint=Identified)
         # Identity has been set by the SBOLObject constructor
         self._display_id = self._extract_display_id(self.identity)
-        self._rdf_types = URIProperty(self, rdflib.RDF.type, 1, math.inf,
+        self._rdf_types = URIProperty(self, RDF_TYPE, 1, math.inf,
                                       initial_value=[type_uri])
 
     @staticmethod

--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -9,7 +9,7 @@ from . import *
 
 class SBOLObject:
 
-    def __init__(self, name: str, type_uri: str) -> None:
+    def __init__(self, name: str) -> None:
         self._properties = defaultdict(list)
         self._owned_objects = defaultdict(list)
         # Does this need to be a property? It does not get serialized to the RDF file.
@@ -17,8 +17,6 @@ class SBOLObject:
         # now, and change to a property in the future if needed.
         self._identity = SBOLObject._make_identity(name)
         self.document = None
-        # This is the URI for this object's type, used for serialization
-        self.type_uri = type_uri
 
     def __setattr__(self, name, value):
         try:

--- a/test/resources/multi-type-ext.nt
+++ b/test/resources/multi-type-ext.nt
@@ -1,0 +1,8 @@
+<http://example.com/foaf/pparker> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
+<http://example.com/foaf/pparker> <http://xmlns.com/foaf/0.1/mbox> <mailto:peter.parker@dailybugle.com> .
+<http://example.com/foaf/pparker> <http://xmlns.com/foaf/0.1/name> "Peter Parker" .
+<http://example.com/sbol3/c1> <http://sbols.org/v3#displayId> "c1" .
+<http://example.com/sbol3/c1> <http://example.com/sbol3#type> <https://identifiers.org/SBO:0000251> .
+<http://example.com/sbol3/c1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#TopLevel> .
+<http://example.com/sbol3/c1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/fake/Type1> .
+<http://example.com/sbol3/c1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/fake/v2#Type2> .

--- a/test/resources/multi-type-sbol.nt
+++ b/test/resources/multi-type-sbol.nt
@@ -1,0 +1,8 @@
+<http://example.com/foaf/pparker> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
+<http://example.com/foaf/pparker> <http://xmlns.com/foaf/0.1/mbox> <mailto:peter.parker@dailybugle.com> .
+<http://example.com/foaf/pparker> <http://xmlns.com/foaf/0.1/name> "Peter Parker" .
+<http://example.com/sbol3/c1> <http://sbols.org/v3#displayId> "c1" .
+<http://example.com/sbol3/c1> <http://sbols.org/v3#type> <https://identifiers.org/SBO:0000251> .
+<http://example.com/sbol3/c1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Component> .
+<http://example.com/sbol3/c1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/fake/Type1> .
+<http://example.com/sbol3/c1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/fake/v2#Type2> .

--- a/test/test_custom.py
+++ b/test/test_custom.py
@@ -58,8 +58,8 @@ class TestCustomTopLevel(unittest.TestCase):
         ctl = sbol3.CustomTopLevel('custom1', custom_type)
         self.assertEqual(custom_type, ctl.type_uri)
         # Go behind the scenes to verify
-        self.assertEqual(rdflib.URIRef(sbol3.SBOL_TOP_LEVEL),
-                         ctl._properties[rdflib.RDF.type][0])
+        expected = [custom_type, sbol3.SBOL_TOP_LEVEL]
+        self.assertCountEqual(expected, ctl._rdf_types)
 
     # TODO: We really want to verify the serialization of the custom top
     #       level as well. There is no Document.writeString() yet.
@@ -128,8 +128,8 @@ class TestCustomIdentified(unittest.TestCase):
                                      type_uri=custom_type)
         self.assertEqual(custom_type, ctl.type_uri)
         # Go behind the scenes to verify
-        self.assertEqual(rdflib.URIRef(sbol3.SBOL_IDENTIFIED),
-                         ctl._properties[rdflib.RDF.type][0])
+        expected = [custom_type, sbol3.SBOL_IDENTIFIED]
+        self.assertCountEqual(expected, ctl._rdf_types)
 
     # TODO: We really want to verify the serialization of the custom
     #       identified as well. We need to attach it to a top level

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -70,10 +70,9 @@ class TestDocument(unittest.TestCase):
     def test_add(self):
         sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         doc = sbol3.Document()
-        type_uri = 'https://github.com/synbiodex/sbol3#TestObj'
-        obj1 = sbol3.SBOLObject('obj', type_uri)
+        non_top_level = sbol3.Interface()
         with self.assertRaises(TypeError):
-            doc.add(obj1)
+            doc.add(non_top_level)
         seq = sbol3.Sequence('seq1')
         doc.add(seq)
         seq2 = doc.find(seq.identity)

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -168,6 +168,30 @@ class TestRoundTrip(unittest.TestCase):
         test_file = os.path.join(TEST_RESOURCE_DIR, 'multi-type-sbol.nt')
         self.run_round_trip_file(test_file, sbol3.NTRIPLES)
 
+    def test_multi_type_ext(self):
+        # Load a file that includes an SBOL object that has multiple other
+        # rdf:type properties
+        test_file = os.path.join(TEST_RESOURCE_DIR, 'multi-type-ext.nt')
+        self.run_round_trip_file(test_file, sbol3.NTRIPLES)
+
+    def test_multi_type_ext_builder(self):
+        class MultiTypeExtension(sbol3.TopLevel):
+            def __init__(self, identity: str, type_uri: str):
+                super().__init__(identity=identity, type_uri=type_uri)
+
+        def mte_builder(identity: str = None,
+                        type_uri: str = None) -> sbol3.Identified:
+            return MultiTypeExtension(identity=identity, type_uri=type_uri)
+
+        ext_type_uri = 'http://example.com/fake/Type1'
+        test_file = os.path.join(TEST_RESOURCE_DIR, 'multi-type-ext.nt')
+        try:
+            sbol3.Document.register_builder(ext_type_uri, mte_builder)
+            self.run_round_trip_file(test_file, sbol3.NTRIPLES)
+        finally:
+            # Reach behind the scenes to remove the registered builder
+            del sbol3.Document._uri_type_map[ext_type_uri]
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -160,6 +160,12 @@ class TestRoundTrip(unittest.TestCase):
         test_file = os.path.join(TEST_RESOURCE_DIR, 'mixed-rdf.nt')
         self.run_round_trip_file(test_file, sbol3.NTRIPLES)
 
+    def test_multi_type_sbol(self):
+        # Load a file that includes an SBOL object that has multiple other
+        # rdf:type properties
+        test_file = os.path.join(TEST_RESOURCE_DIR, 'multi-type-sbol.nt')
+        self.run_round_trip_file(test_file, sbol3.NTRIPLES)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Allow multiple rdf:type properties to be stored. When reading and
writing SBOL documents, store and write all the rdf:type properties
associated with an object.

Fixes #214