### PR TITLE
Update to new SBOLTestSuite/SBOL3

### DIFF
--- a/sbol3/location.py
+++ b/sbol3/location.py
@@ -156,4 +156,4 @@ def build_entire_sequence(identity: str, type_uri: str = SBOL_ENTIRE_SEQUENCE):
     return obj
 
 
-Document.register_builder(SBOL_ENTIRE_SEQUENCE, EntireSequence)
+Document.register_builder(SBOL_ENTIRE_SEQUENCE, build_entire_sequence)

--- a/sbol3/seqfeat.py
+++ b/sbol3/seqfeat.py
@@ -29,7 +29,8 @@ class SequenceFeature(Feature):
 
 def build_sequence_feature(identity: str,
                            *, type_uri: str = SBOL_SEQUENCE_FEATURE) -> SBOLObject:
-    obj = SequenceFeature([EntireSequence()], identity=identity, type_uri=type_uri)
+    obj = SequenceFeature([EntireSequence(PYSBOL3_MISSING)],
+                          identity=identity, type_uri=type_uri)
     # Remove the dummy values
     obj._properties[SBOL_LOCATION] = []
     return obj

--- a/sbol3/seqfeat.py
+++ b/sbol3/seqfeat.py
@@ -32,7 +32,7 @@ def build_sequence_feature(identity: str,
     obj = SequenceFeature([EntireSequence(PYSBOL3_MISSING)],
                           identity=identity, type_uri=type_uri)
     # Remove the dummy values
-    obj._properties[SBOL_LOCATION] = []
+    obj._owned_objects[SBOL_LOCATION] = []
     return obj
 
 

--- a/test/test_attachment.py
+++ b/test/test_attachment.py
@@ -28,7 +28,7 @@ class TestAttachment(unittest.TestCase):
                                  'attachment.nt')
         doc = sbol3.Document()
         doc.read(test_file, sbol3.NTRIPLES)
-        search_uri = 'http://parts.igem.org/Part:/attachment1'
+        search_uri = 'https://sbolstandard.org/examples/attachment1'
         attachment = doc.find(search_uri)
         self.assertIsNotNone(attachment)
         self.assertIsInstance(attachment, sbol3.Attachment)

--- a/test/test_compref.py
+++ b/test/test_compref.py
@@ -28,13 +28,13 @@ class TestComponentReference(unittest.TestCase):
                                  'toggle_switch.nt')
         doc = sbol3.Document()
         doc.read(test_file, sbol3.NTRIPLES)
-        uri = 'https://sbolstandard.org/examples/toggle_switch/componentreference_1'
+        uri = 'https://sbolstandard.org/examples/toggle_switch/ComponentReference1'
         comp_ref = doc.find(uri)
         self.assertIsNotNone(comp_ref)
         self.assertIsInstance(comp_ref, sbol3.ComponentReference)
-        in_child_of = 'https://sbolstandard.org/examples/toggle_switch/LacI_producer'
+        in_child_of = 'https://sbolstandard.org/examples/toggle_switch/SubComponent1'
         self.assertEqual(in_child_of, comp_ref.in_child_of)
-        feature = 'https://sbolstandard.org/examples/LacI_producer/LacI_protein'
+        feature = 'https://sbolstandard.org/examples/LacI_producer/SubComponent7'
         self.assertEqual(feature, comp_ref.feature)
 
 

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -193,13 +193,12 @@ class TestDocument(unittest.TestCase):
         # We should find the validation issue in the Range
         self.assertEqual(1, len(report))
 
-    @unittest.expectedFailure
     def test_find_all(self):
         test_files = {
             os.path.join(SBOL3_LOCATION, 'entity', 'model',
                          'model.nt'): 2,
             os.path.join(SBOL3_LOCATION, 'multicellular',
-                         'multicellular.nt'): 77,
+                         'multicellular.nt'): 75,
         }
         for file, count in test_files.items():
             doc = sbol3.Document()
@@ -216,7 +215,6 @@ class TestDocument(unittest.TestCase):
         found = doc.find_all(lambda obj: isinstance(obj, sbol3.Participation))
         self.assertEqual(11, len(found))
 
-    @unittest.expectedFailure
     def test_visit_all(self):
         visited_list = []
 
@@ -227,7 +225,7 @@ class TestDocument(unittest.TestCase):
         doc = sbol3.Document()
         doc.read(file)
         doc.accept(my_visitor)
-        self.assertEqual(77, len(visited_list))
+        self.assertEqual(75, len(visited_list))
 
     def test_visit_participations(self):
         # Visit all and only the participations

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -193,6 +193,7 @@ class TestDocument(unittest.TestCase):
         # We should find the validation issue in the Range
         self.assertEqual(1, len(report))
 
+    @unittest.expectedFailure
     def test_find_all(self):
         test_files = {
             os.path.join(SBOL3_LOCATION, 'entity', 'model',
@@ -215,6 +216,7 @@ class TestDocument(unittest.TestCase):
         found = doc.find_all(lambda obj: isinstance(obj, sbol3.Participation))
         self.assertEqual(11, len(found))
 
+    @unittest.expectedFailure
     def test_visit_all(self):
         visited_list = []
 

--- a/test/test_extdef.py
+++ b/test/test_extdef.py
@@ -1,4 +1,5 @@
 import os
+import posixpath
 import unittest
 
 import sbol3
@@ -28,14 +29,14 @@ class TestExternallyDefined(unittest.TestCase):
                                  'measurement', 'measurement.nt')
         doc = sbol3.Document()
         doc.read(test_file, sbol3.NTRIPLES)
-        uri = 'https://sbolstandard.org/examples/M9_Glucose_CAA/CaCl2'
+        uri = 'https://sbolstandard.org/examples/M9_Glucose_CAA/ExternallyDefined1'
         ext_def = doc.find(uri)
         self.assertIsNotNone(ext_def)
         self.assertIsInstance(ext_def, sbol3.ExternallyDefined)
         self.assertCountEqual(['https://identifiers.org/SBO:0000247'], ext_def.types)
         self.assertEqual('https://identifiers.org/CHEBI:3312', ext_def.definition)
-        self.assertEqual('CaCl2', ext_def.display_id)
+        self.assertEqual('ExternallyDefined1', ext_def.display_id)
         self.assertEqual(1, len(ext_def.measures))
         measure = ext_def.measures[0]
-        measure_uri = 'https://sbolstandard.org/examples/M9_Glucose_CAA/CaCl2/measure1'
+        measure_uri = posixpath.join(uri, 'measure1')
         self.assertEqual(measure_uri, measure.identity)

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -25,13 +25,13 @@ class TestInterface(unittest.TestCase):
                                  'interface.nt')
         doc = sbol3.Document()
         doc.read(test_file, sbol3.NTRIPLES)
-        search_uri = 'https://sbolstandard.org/examples/LacI_producer/interface'
+        search_uri = 'https://sbolstandard.org/examples/LacI_producer/Interface1'
         interface = doc.find(search_uri)
         self.assertIsNotNone(interface)
         self.assertIsInstance(interface, sbol3.Interface)
-        tetr_uri = 'https://sbolstandard.org/examples/LacI_producer/TetR_protein'
-        laci_uri = 'https://sbolstandard.org/examples/LacI_producer/LacI_protein'
-        atc_uri = 'https://sbolstandard.org/examples/LacI_producer/aTC'
+        tetr_uri = 'https://sbolstandard.org/examples/LacI_producer/SubComponent2'
+        laci_uri = 'https://sbolstandard.org/examples/LacI_producer/SubComponent1'
+        atc_uri = 'https://sbolstandard.org/examples/LacI_producer/SubComponent3'
         iface_input = [tetr_uri, laci_uri]
         self.assertCountEqual(iface_input, interface.input)
         output = [laci_uri]

--- a/test/test_om_unit.py
+++ b/test/test_om_unit.py
@@ -1,4 +1,5 @@
 import os
+import posixpath
 import unittest
 
 import sbol3
@@ -33,7 +34,8 @@ class TestMeasure(unittest.TestCase):
                                  'measurement', 'measurement.nt')
         doc = sbol3.Document()
         doc.read(test_file, sbol3.NTRIPLES)
-        uri = 'https://sbolstandard.org/examples/M9_Glucose_CAA/CaCl2/measure1'
+        namespace = 'https://sbolstandard.org/examples'
+        uri = posixpath.join(namespace, 'M9_Glucose_CAA/ExternallyDefined1/measure1')
         measure = doc.find(uri)
         self.assertIsNotNone(measure)
         self.assertIsInstance(measure, sbol3.Measure)
@@ -122,7 +124,7 @@ class TestSingularUnit(unittest.TestCase):
         self.assertIsInstance(sunit, sbol3.SingularUnit)
         self.assertEqual(0.001, sunit.factor)
         self.assertIsNone(sunit.unit)
-        self.assertIsNone(sunit.symbol)
+        self.assertEqual('l', sunit.symbol)
         self.assertCountEqual(['L', 'L2'], sunit.alternative_symbols)
         self.assertEqual('liter', sunit.label)
         self.assertCountEqual(['liter', 'litre2'], sunit.alternative_labels)

--- a/test/test_participation.py
+++ b/test/test_participation.py
@@ -28,11 +28,11 @@ class TestParticipation(unittest.TestCase):
         doc = sbol3.Document()
         doc.read(test_file, sbol3.NTRIPLES)
         search_uri = ('https://sbolstandard.org/examples/'
-                      'LacI_producer/interaction_2/participation_1')
+                      'LacI_producer/Interaction2/Participation1')
         participation = doc.find(search_uri)
         self.assertIsNotNone(participation)
         self.assertIsInstance(participation, sbol3.Participation)
-        participant = 'https://sbolstandard.org/examples/LacI_producer/subcomponent_5'
+        participant = 'https://sbolstandard.org/examples/LacI_producer/SubComponent5'
         self.assertEqual(participant, participation.participant)
         roles = [sbol3.SBO_TEMPLATE]
         self.assertEqual(roles, participation.roles)

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -41,11 +41,11 @@ class TestRoundTrip(unittest.TestCase):
                                  'BBa_F2620_PoPSReceiver.ttl')
         doc = sbol3.Document()
         doc.read(sbol_path, sbol3.TURTLE)
-        uri = 'https://synbiohub.org/public/igem/BBa_F2620/subcomponent_3/location_1'
+        uri = 'https://synbiohub.org/public/igem/BBa_F2620/SubComponent3/Range1'
         range1 = doc.find(uri)
         self.assertIsNotNone(range1)
-        self.assertEqual(55, range1.start)
-        self.assertEqual(108, range1.end)
+        self.assertEqual(1, range1.start)
+        self.assertEqual(53, range1.end)
 
     def find_all_files(self, dirname: str):
         for item in os.listdir(dirname):
@@ -136,6 +136,7 @@ class TestRoundTrip(unittest.TestCase):
                 self.logger.debug('Only in loaded: %r', stmt)
             self.fail('Differences in RDF detected')
 
+    @unittest.expectedFailure
     def test_sbol3_files(self):
         test_dir = SBOL3_LOCATION
         # No files are skipped at this time. All SBOLTestSuite files can

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -136,12 +136,13 @@ class TestRoundTrip(unittest.TestCase):
                 self.logger.debug('Only in loaded: %r', stmt)
             self.fail('Differences in RDF detected')
 
-    @unittest.expectedFailure
     def test_sbol3_files(self):
         test_dir = SBOL3_LOCATION
         # No files are skipped at this time. All SBOLTestSuite files can
         # be round-tripped.
         skip_list = [
+            'component_urn_uri',
+            'component_urn_uri_ordered'
         ]
         for test_file in self.find_all_files(test_dir):
             basename = os.path.basename(test_file)


### PR DESCRIPTION
Test files now use compliant URIs so unit tests that relied on the old URIs needed to be updated. One or two values also changed so some unit tests were updated accordingly. A genuine bug with the EntireSequence builder was uncovered, and a related bug in the SequenceFeature builder.

There is a remaining issue (#220) round tripping component_urn_uri files so they are currently skipped by the round trip test.

Closes #218 