### PR TITLE
Add JSON-LD test suite file to round trip testing

### DIFF
--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -68,6 +68,8 @@ class TestRoundTrip(unittest.TestCase):
             'nt': sbol3.NTRIPLES,
             'ttl': sbol3.TURTLE,
             'rdf': sbol3.RDF_XML,
+            'jsonld': sbol3.JSONLD,
+            'jsonld_expanded': sbol3.JSONLD,
         }
         if ext in ext_map:
             return ext_map[ext]


### PR DESCRIPTION
The JSON-LD files in the SBOLTestSuite have been fixed and
expanded. Incorporate them into the round trip testing.

See #218 