### PR TITLE
Handle identities of the form `urn:uuid:UUID-GOES-HERE`

### DIFF
--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -60,7 +60,7 @@ class SBOLObject:
         try:
             # If it is a UUID, accept it as the identity
             identity_uuid = uuid.UUID(name)
-            return str(identity_uuid)
+            return name
         except ValueError:
             pass
         # Not a URL or a UUID, so append to the namespace

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -143,8 +143,6 @@ class TestRoundTrip(unittest.TestCase):
         # No files are skipped at this time. All SBOLTestSuite files can
         # be round-tripped.
         skip_list = [
-            'component_urn_uri',
-            'component_urn_uri_ordered',
             # Waiting for https://github.com/SynBioDex/SBOLTestSuite/issues/33
             'annotation',
             'annotation_ordered',


### PR DESCRIPTION
Do not parse and replace the URN form with just the UUID. Leave it
intact after determining that it was a UUID. Restore the
component_urn_uri round trip tests to the working state.

Fixes #220 