### PR TITLE
Make document assignment recursive

### DIFF
--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -89,6 +89,15 @@ class Identified(SBOLObject):
     @document.setter
     def document(self, value):
         self._document = value
+        # Now assign document to the whole object hierarchy
+        # rooted here
+        # Note: we prevent an infinite loop by assigning to
+        # `_document` instead of recursively entering this
+        # method by assigning to `document`.
+
+        def assign_document(x: Identified):
+            x._document = value
+        self.accept(assign_document)
 
     def _validate_display_id(self, report: ValidationReport) -> None:
         if self.identity_is_url():

--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -23,6 +23,7 @@ class Identified(SBOLObject):
                  derived_from: List[str] = None, generated_by: List[str] = None,
                  measures: List[SBOLObject] = None) -> None:
         super().__init__(identity)
+        self._document = None
         self._display_id = TextProperty(self, SBOL_DISPLAY_ID, 0, 1)
         self.name = TextProperty(self, SBOL_NAME, 0, 1, initial_value=name)
         self.description = TextProperty(self, SBOL_DESCRIPTION, 0, 1,
@@ -80,6 +81,14 @@ class Identified(SBOLObject):
     @property
     def type_uri(self):
         return self._rdf_types[0]
+
+    @property
+    def document(self):
+        return self._document
+
+    @document.setter
+    def document(self, value):
+        self._document = value
 
     def _validate_display_id(self, report: ValidationReport) -> None:
         if self.identity_is_url():

--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -16,7 +16,6 @@ class SBOLObject:
         # Could it be an attribute that gets composed on the fly? Keep it simple for
         # now, and change to a property in the future if needed.
         self._identity = SBOLObject._make_identity(name)
-        self.document = None
 
     def __setattr__(self, name, value):
         try:

--- a/test/test_ownedobject.py
+++ b/test/test_ownedobject.py
@@ -149,6 +149,31 @@ class TestOwnedObject(unittest.TestCase):
     # TODO: Write tests for adding via a slice
     #       comp.constraints[0:1] = sbol3.Constraint('foo')
 
+    def test_compose_then_set_document(self):
+        # Ensure that document is set on child objects
+        # See https://github.com/SynBioDex/pySBOL3/issues/230
+        sbol3.set_namespace('https://bioprotocols.org/paml/primitives/')
+        c = sbol3.Component("scratch", sbol3.SBO_DNA)
+        lsc = sbol3.LocalSubComponent([sbol3.SBO_DNA])
+        self.assertIsNone(lsc.document)
+        c.features.append(lsc)
+        doc = sbol3.Document()
+        doc.add(c)
+        self.assertIsNotNone(lsc.document)
+        self.assertEqual(doc, lsc.document)
+        interaction = sbol3.Interaction([sbol3.SBO_DEGRADATION])
+        p = sbol3.Participation([sbol3.SBO_REACTANT], lsc)
+        interaction.participations.append(p)
+        c.interactions.append(interaction)
+        # Now that we've composed the objects, add them to the parent.
+        # This should assign the document to all the objects in the hierarchy
+        # See https://github.com/SynBioDex/pySBOL3/issues/230
+        self.assertEqual(doc, interaction.document)
+        self.assertEqual(doc, p.document)
+        resolved_lsc = p.participant.lookup()
+        self.assertEqual(lsc, resolved_lsc)
+        self.assertEqual(lsc.identity, resolved_lsc.identity)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Set document for the entire object hierarchy rather than just the root object. This is consistent with `Document.add()`.

Fixes #230 