### PR TITLE
Implement visitor pattern

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ and constructing genetic designs according to the standardized specifications of
    introduction
    installation
    extensions
+   visitor
    ontology
 ..   getting_started
 ..   repositories

--- a/docs/repositories.rst
+++ b/docs/repositories.rst
@@ -53,9 +53,9 @@ The ``pull`` operation will retrieve ``ComponentDefinitions`` and their associat
 
 .. end
 
---------------------
+------------------------
 Logging in to Part Repos
---------------------
+------------------------
 
 Some parts repositories can be accessed as above, without
 authenticating to the parts repository. You may also have access to

--- a/docs/visitor.rst
+++ b/docs/visitor.rst
@@ -1,0 +1,108 @@
+Using Visitors
+==============
+
+The Visitor Pattern is a well known and commonly used pattern for
+performing an operation on the elements of an object structure. There
+are many online resources for learning about the visitor pattern.
+
+The implementation of the Visitor Pattern in pySBOL3 is very
+simple. When a pySBOL3 object's `accept` method is called, a visitor
+is passed as the only arugment. The `accept` method, in turn, invokes
+`visit_type` on the visitor, passing the pySBOL3 object as the only
+argument.
+
+Traversal of the pySBOL3 object graph is left to the visitor
+itself. When a `visit_type` method is called, the visitor must then
+invoke `accept` on any child objects it might want to visit. See the
+code sample below for an example of this traversal.
+
+
+Resources
+---------
+* https://sourcemaking.com/design_patterns/visitor
+* https://refactoring.guru/design-patterns/visitor
+* https://www.informit.com/store/design-patterns-elements-of-reusable-object-oriented-9780201633610
+
+
+Example Code
+------------
+
+The program below will visit each top level object in the document as
+well as visiting any features on the top level components. Note that
+the visitor must direct the traversal of the features, as discussed
+above.
+
+.. code:: python
+
+  import sbol3
+
+
+  class MyVisitor:
+
+      def visit_component(self, c: sbol3.Component):
+          print(f'Component {c.identity}')
+          for f in c.features:
+              f.accept(self)
+
+      def visit_sequence(self, s: sbol3.Component):
+          print(f'Sequence {s.identity}')
+
+      def visit_sub_component(self, sc: sbol3.Component):
+          print(f'SubComponent {sc.identity}')
+
+
+  doc = sbol3.Document()
+  doc.read('test/SBOLTestSuite/SBOL3/BBa_F2620_PoPSReceiver/BBa_F2620_PoPSReceiver.ttl')
+  visitor = MyVisitor()
+  for obj in doc.objects:
+      obj.accept(visitor)
+.. end
+
+
+Visit Methods
+-------------
+
+The table below lists each class that has an accept method and the
+corresponding method that is invoked on the visitor passed to the
+accept method.
+
+=======================  ============
+Class                    Visit Method
+=======================  ============
+Activity                 visit_activity
+Agent                    visit_agent
+Association              visit_association
+Attachment               visit_attachment
+BinaryPrefix             visit_binary_prefix
+Collection               visit_collection
+CombinatorialDerivation  visit_combinatorial_derivation
+Component                visit_component
+ComponentReference       visit_component_reference
+Constraint               visit_constraint
+Cut                      visit_cut
+Document                 visit_document(self)
+EntireSequence           visit_entire_sequence
+Experiment               visit_experiment
+ExperimentalData         visit_experimental_data
+ExternallyDefined        visit_externally_defined
+Implementation           visit_implementation
+Interaction              visit_interaction
+Interface                visit_interface
+LocalSubComponent        visit_local_sub_component
+Measure                  visit_measure
+Model                    visit_model
+Participation            visit_participation
+Plan                     visit_plan
+PrefixedUnit             visit_prefixed_unit
+Range                    visit_range
+SIPrefix                 visit_si_prefix
+Sequence                 visit_sequence
+SequenceFeature          visit_sequence_feature
+SingularUnit             visit_singular_unit
+SubComponent             visit_sub_component
+UnitDivision             visit_unit_division
+UnitExponentiation       visit_unit_exponentiation
+UnitMultiplication       visit_unit_multiplication
+Usage                    visit_usage
+VariableFeature          visit_variable_feature
+=======================  ============

--- a/examples/visitor.py
+++ b/examples/visitor.py
@@ -89,7 +89,7 @@ def main(argv=None):
     doc = sbol3.Document()
     doc.read(args.inputfile)
     my_visitor = MyVisitor()
-    doc.accept(my_visitor)
+    doc.traverse(my_visitor)
 
 
 if __name__ == '__main__':

--- a/examples/visitor.py
+++ b/examples/visitor.py
@@ -1,69 +1,35 @@
 import argparse
 import logging
-from typing import Any
 
 import sbol3
 
-# This example demonstrates how to adapt the functional vistor pattern
-# in pySBOL3 to an object oriented visitor pattern similar to
-# https://refactoring.guru/design-patterns/visitor/python/example or
-# https://en.wikipedia.org/wiki/Visitor_pattern#Python_example
-
+# This example demonstrates how to use the visitor pattern
+# in pySBOL3 to navigate a document
+#
 # Usage:
 #
 #    python3 visitor.py [-d] SBOL_FILE_NAME
 
 
-class SBOLVisitor:
-    """A base class for visitor pySBOL3 visitors.
-    """
-
-    def __call__(self, sbol_object: sbol3.Identified):
-        """This method is invoked on every SBOL object that is visited. The
-        visit is then dispatched to a type-specific method. If no
-        type-specific method exists, `visit_fallback` is invoked with
-        the SBOL object. The default implementation of
-        `visit_fallback` does nothing.
-
-        """
-        method_name = self._method_name(sbol_object)
-        try:
-            getattr(self, method_name)(sbol_object)
-        except AttributeError:
-            self.visit_fallback(sbol_object)
-
-    def _method_name(self, thing: Any) -> str:
-        """Generates a visitor method name for a given object. Override this
-        method if you want a different conversion from object to
-        method name.
-
-        """
-        qualname = type(thing).__qualname__.replace(".", "_")
-        return f'visit_{qualname}'
-
-    def visit_fallback(self, sbol_object: sbol3.Identified):
-        """Visit an object that doesn't have a specific method for its type.
-        Override this method to catch objects that do not have a
-        specific visit method defined for them.
-
-        """
-        pass
-
-
-class MyVisitor(SBOLVisitor):
+class MyVisitor:
     """An example visitor.
 
     """
 
-    def visit_Component(self, c):
+    def visit_document(self, doc: sbol3.Document):
+        for obj in doc.objects:
+            obj.accept(self)
+
+    def visit_component(self, c: sbol3.Component):
+        for feature in c.features:
+            feature.accept(self)
         print(f'Visited Component {c.identity}')
 
-    def visit_SubComponent(self, sc):
-        print(f'Visited SubComponent {sc.identity}')
+    def visit_component_reference(self, cr: sbol3.ComponentReference):
+        print(f'Visited ComponentReference {cr.identity}')
 
-    def visit_fallback(self, sbol_object: sbol3.Identified):
-        type_name = type(sbol_object).__qualname__
-        logging.debug(f'Fallback visit of {type_name} {sbol_object.identity}')
+    def visit_sub_component(self, sc: sbol3.SubComponent):
+        print(f'Visited SubComponent {sc.identity}')
 
 
 def parse_args(args=None):
@@ -89,7 +55,7 @@ def main(argv=None):
     doc = sbol3.Document()
     doc.read(args.inputfile)
     my_visitor = MyVisitor()
-    doc.traverse(my_visitor)
+    doc.accept(my_visitor)
 
 
 if __name__ == '__main__':

--- a/sbol3/attachment.py
+++ b/sbol3/attachment.py
@@ -44,6 +44,9 @@ class Attachment(TopLevel):
             report.addError(self.identity, None, message)
         return report
 
+    def accept(self, visitor):
+        visitor.visit_attachment(self)
+
 
 def build_attachment(identity: str,
                      *, type_uri: str = SBOL_COMPONENT) -> SBOLObject:

--- a/sbol3/attachment.py
+++ b/sbol3/attachment.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Any
 
 from . import *
 
@@ -44,7 +44,7 @@ class Attachment(TopLevel):
             report.addError(self.identity, None, message)
         return report
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_attachment` on `visitor` with `self` as the only
         argument.
 

--- a/sbol3/attachment.py
+++ b/sbol3/attachment.py
@@ -45,6 +45,16 @@ class Attachment(TopLevel):
         return report
 
     def accept(self, visitor):
+        """Invokes `visit_attachment` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_attachment method
+        :return: Whatever `visitor.visit_attachment` returns
+        :rtype: Any
+
+        """
         visitor.visit_attachment(self)
 
 

--- a/sbol3/collection.py
+++ b/sbol3/collection.py
@@ -1,5 +1,5 @@
 import math
-from typing import List
+from typing import List, Any
 
 from . import *
 
@@ -37,7 +37,7 @@ class Collection(TopLevel):
         self.members = ReferencedObject(self, SBOL_MEMBER, 0, math.inf,
                                         initial_value=members)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_collection` on `visitor` with `self` as the only
         argument.
 
@@ -75,7 +75,7 @@ class Experiment(Collection):
                          description=description, derived_from=derived_from,
                          generated_by=generated_by, measures=measures)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_experiment` on `visitor` with `self` as the only
         argument.
 

--- a/sbol3/collection.py
+++ b/sbol3/collection.py
@@ -37,6 +37,9 @@ class Collection(TopLevel):
         self.members = ReferencedObject(self, SBOL_MEMBER, 0, math.inf,
                                         initial_value=members)
 
+    def accept(self, visitor):
+        visitor.visit_collection(self)
+
 
 class Experiment(Collection):
     """The purpose of the Experiment class is to aggregate
@@ -61,6 +64,9 @@ class Experiment(Collection):
                          attachments=attachments, name=name,
                          description=description, derived_from=derived_from,
                          generated_by=generated_by, measures=measures)
+
+    def accept(self, visitor):
+        visitor.visit_experiment(self)
 
 
 Document.register_builder(SBOL_COLLECTION, Collection)

--- a/sbol3/collection.py
+++ b/sbol3/collection.py
@@ -38,6 +38,16 @@ class Collection(TopLevel):
                                         initial_value=members)
 
     def accept(self, visitor):
+        """Invokes `visit_collection` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_collection method
+        :return: Whatever `visitor.visit_collection` returns
+        :rtype: Any
+
+        """
         visitor.visit_collection(self)
 
 
@@ -66,6 +76,16 @@ class Experiment(Collection):
                          generated_by=generated_by, measures=measures)
 
     def accept(self, visitor):
+        """Invokes `visit_experiment` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_experiment method
+        :return: Whatever `visitor.visit_experiment` returns
+        :rtype: Any
+
+        """
         visitor.visit_experiment(self)
 
 

--- a/sbol3/combderiv.py
+++ b/sbol3/combderiv.py
@@ -1,5 +1,5 @@
 import math
-from typing import Union, List
+from typing import Union, List, Any
 
 from . import *
 
@@ -50,7 +50,7 @@ class CombinatorialDerivation(TopLevel):
                 report.addError(self.identity, None, message)
         return report
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_combinatorial_derivation` on `visitor` with `self`
         as the only argument.
 

--- a/sbol3/combderiv.py
+++ b/sbol3/combderiv.py
@@ -50,6 +50,9 @@ class CombinatorialDerivation(TopLevel):
                 report.addError(self.identity, None, message)
         return report
 
+    def accept(self, visitor):
+        visitor.visit_combinatorial_derivation(self)
+
 
 def build_combinatorial_derivation(identity: str,
                                    *, type_uri: str = SBOL_COMBINATORIAL_DERIVATION):

--- a/sbol3/combderiv.py
+++ b/sbol3/combderiv.py
@@ -51,6 +51,17 @@ class CombinatorialDerivation(TopLevel):
         return report
 
     def accept(self, visitor):
+        """Invokes `visit_combinatorial_derivation` on `visitor` with `self`
+        as the only argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_combinatorial_derivation
+                                method
+        :return: Whatever `visitor.visit_combinatorial_derivation` returns
+        :rtype: Any
+
+        """
         visitor.visit_combinatorial_derivation(self)
 
 

--- a/sbol3/component.py
+++ b/sbol3/component.py
@@ -47,6 +47,9 @@ class Component(TopLevel):
         self.models = ReferencedObject(self, SBOL_MODELS, 0, math.inf,
                                        initial_value=models)
 
+    def accept(self, visitor):
+        visitor.visit_component(self)
+
 
 def build_component(identity: str, *, type_uri: str = SBOL_COMPONENT) -> SBOLObject:
     missing = PYSBOL3_MISSING

--- a/sbol3/component.py
+++ b/sbol3/component.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, Union
+from typing import List, Union, Any
 
 from . import *
 
@@ -47,7 +47,17 @@ class Component(TopLevel):
         self.models = ReferencedObject(self, SBOL_MODELS, 0, math.inf,
                                        initial_value=models)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
+        """Invokes `visit_component` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_component method
+        :return: Whatever `visitor.visit_component` returns
+        :rtype: Any
+
+        """
         visitor.visit_component(self)
 
 

--- a/sbol3/compref.py
+++ b/sbol3/compref.py
@@ -1,4 +1,4 @@
-from typing import Union, List
+from typing import Union, List, Any
 
 from . import *
 # Feature is not exported
@@ -41,7 +41,7 @@ class ComponentReference(Feature):
             report.addError(self.identity, None, message)
         return report
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_component_reference` on `visitor` with `self` as the
         only argument.
 

--- a/sbol3/compref.py
+++ b/sbol3/compref.py
@@ -42,6 +42,17 @@ class ComponentReference(Feature):
         return report
 
     def accept(self, visitor):
+        """Invokes `visit_component_reference` on `visitor` with `self` as the
+        only argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_component_reference
+                                method
+        :return: Whatever `visitor.visit_component_reference` returns
+        :rtype: Any
+
+        """
         visitor.visit_component_reference(self)
 
 

--- a/sbol3/compref.py
+++ b/sbol3/compref.py
@@ -41,6 +41,9 @@ class ComponentReference(Feature):
             report.addError(self.identity, None, message)
         return report
 
+    def accept(self, visitor):
+        visitor.visit_component_reference(self)
+
 
 def build_component_reference(identity: str, *,
                               type_uri: str = SBOL_COMPONENT_REFERENCE) -> SBOLObject:

--- a/sbol3/constraint.py
+++ b/sbol3/constraint.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Any
 
 from . import *
 
@@ -47,7 +47,7 @@ class Constraint(Identified):
             report.addError(self.identity, None, message)
         return report
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_constraint` on `visitor` with `self` as the only
         argument.
 

--- a/sbol3/constraint.py
+++ b/sbol3/constraint.py
@@ -48,6 +48,16 @@ class Constraint(Identified):
         return report
 
     def accept(self, visitor):
+        """Invokes `visit_constraint` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_constraint method
+        :return: Whatever `visitor.visit_constraint` returns
+        :rtype: Any
+
+        """
         visitor.visit_constraint(self)
 
 

--- a/sbol3/constraint.py
+++ b/sbol3/constraint.py
@@ -47,6 +47,9 @@ class Constraint(Identified):
             report.addError(self.identity, None, message)
         return report
 
+    def accept(self, visitor):
+        visitor.visit_constraint(self)
+
 
 def build_constraint(identity: str, type_uri: str = SBOL_CONSTRAINT) -> SBOLObject:
     missing = PYSBOL3_MISSING

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -256,7 +256,7 @@ class Document:
         # in the TopLevel being added
         def assign_document(x: Identified):
             x.document = self
-        obj.accept(assign_document)
+        obj.traverse(assign_document)
 
     def _find_in_objects(self, search_string: str) -> Optional[Identified]:
         # TODO: implement recursive search
@@ -376,35 +376,15 @@ class Document:
         def wrapped_filter(visited: Identified):
             if predicate(visited):
                 result.append(visited)
-        self.accept(wrapped_filter)
+        self.traverse(wrapped_filter)
         return result
 
-    # TODO: Implement the visitor pattern allowing the user to specify
-    #       a function to direct the search, instead of only doing
-    #       depth-first search. For example, visit objects in provenance
-    #       order using Identified.derived_from.
-    # def accept_with_strategy(self, visitor: Callable, *, strategy: Callable = None):
-    #     # Use the strategy to compute the set of objects to visit
-    #     if strategy is None:
-    #         visit_list = self.objects
-    #     else:
-    #         visit_list = self.find_all(strategy)
-    #     while visit_list:
-    #         for obj in visit_list:
-    #             obj.accept(visitor)
-    #         # Compute the next set of objects to visit
-    #         if strategy is None:
-    #             visit_list = []
-    #         else:
-    #             visit_list = self.find_all(strategy)
-
-    def accept(self, visitor: Callable[[Identified], None]):
-        """Implement the visitor pattern by invoking `visitor` on all
-        top-level objects in the document. Those objects, in turn, will
-        invoke `visitor` on all of their child objects.
+    def traverse(self, func: Callable[[Identified], None]):
+        """Enable a traversal of the entire object hierarchy contained
+        in this document.
         """
         for obj in self.objects:
-            obj.accept(visitor)
+            obj.traverse(func)
 
     def builder(self, type_uri: str) -> Callable[[str, str], Identified]:
         """Lookup up the builder callable for the given type_uri.

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -380,6 +380,16 @@ class Document:
         return result
 
     def accept(self, visitor):
+        """Invokes `visit_document` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_document method
+        :return: Whatever `visitor.visit_document` returns
+        :rtype: Any
+
+        """
         visitor.visit_document(self)
 
     def traverse(self, func: Callable[[Identified], None]):

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -1,7 +1,7 @@
 import collections
 import logging
 import warnings
-from typing import Dict, Callable, List, Optional
+from typing import Dict, Callable, List, Optional, Any
 
 import rdflib
 # Get the rdflib-jsonld capability initialized
@@ -379,7 +379,7 @@ class Document:
         self.traverse(wrapped_filter)
         return result
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_document` on `visitor` with `self` as the only
         argument.
 

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -379,6 +379,9 @@ class Document:
         self.traverse(wrapped_filter)
         return result
 
+    def accept(self, visitor):
+        visitor.visit_document(self)
+
     def traverse(self, func: Callable[[Identified], None]):
         """Enable a traversal of the entire object hierarchy contained
         in this document.

--- a/sbol3/expdata.py
+++ b/sbol3/expdata.py
@@ -26,5 +26,8 @@ class ExperimentalData(TopLevel):
                          description=description, derived_from=derived_from,
                          generated_by=generated_by, measures=measures)
 
+    def accept(self, visitor):
+        visitor.visit_experimental_data(self)
+
 
 Document.register_builder(SBOL_EXPERIMENTAL_DATA, ExperimentalData)

--- a/sbol3/expdata.py
+++ b/sbol3/expdata.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Any
 
 from . import *
 
@@ -26,7 +26,7 @@ class ExperimentalData(TopLevel):
                          description=description, derived_from=derived_from,
                          generated_by=generated_by, measures=measures)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_experimental_data` on `visitor` with `self` as the
         only argument.
 

--- a/sbol3/expdata.py
+++ b/sbol3/expdata.py
@@ -27,6 +27,17 @@ class ExperimentalData(TopLevel):
                          generated_by=generated_by, measures=measures)
 
     def accept(self, visitor):
+        """Invokes `visit_experimental_data` on `visitor` with `self` as the
+        only argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_experimental_data
+                                method
+        :return: Whatever `visitor.visit_experimental_data` returns
+        :rtype: Any
+
+        """
         visitor.visit_experimental_data(self)
 
 

--- a/sbol3/extdef.py
+++ b/sbol3/extdef.py
@@ -42,6 +42,17 @@ class ExternallyDefined(Feature):
         return report
 
     def accept(self, visitor):
+        """Invokes `visit_externally_defined` on `visitor` with `self` as the
+        only argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_externally_defined
+                                method
+        :return: Whatever `visitor.visit_externally_defined` returns
+        :rtype: Any
+
+        """
         visitor.visit_externally_defined(self)
 
 

--- a/sbol3/extdef.py
+++ b/sbol3/extdef.py
@@ -1,4 +1,5 @@
 import math
+from typing import Any
 
 from . import *
 
@@ -41,7 +42,7 @@ class ExternallyDefined(Feature):
             report.addError(self.identity, None, message)
         return report
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_externally_defined` on `visitor` with `self` as the
         only argument.
 

--- a/sbol3/extdef.py
+++ b/sbol3/extdef.py
@@ -41,6 +41,9 @@ class ExternallyDefined(Feature):
             report.addError(self.identity, None, message)
         return report
 
+    def accept(self, visitor):
+        visitor.visit_externally_defined(self)
+
 
 def build_externally_defined(identity: str,
                              *, type_uri: str = SBOL_EXTERNALLY_DEFINED) -> SBOLObject:

--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -208,6 +208,10 @@ class Identified(SBOLObject):
                 graph.add((identity, rdf_prop, rdflib.URIRef(item.identity)))
                 item.serialize(graph)
 
+    def accept(self, visitor):
+        message = f'accept is not implemented for {type(self).__qualname__}'
+        raise NotImplementedError(message)
+
     def traverse(self, func: Callable[['Identified'], None]):
         """Enable a traversal of this object and all of its children by
         invoking the passed function on all objects.

--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -97,7 +97,7 @@ class Identified(SBOLObject):
 
         def assign_document(x: Identified):
             x._document = value
-        self.accept(assign_document)
+        self.traverse(assign_document)
 
     def _validate_display_id(self, report: ValidationReport) -> None:
         if self.identity_is_url():
@@ -208,11 +208,12 @@ class Identified(SBOLObject):
                 graph.add((identity, rdf_prop, rdflib.URIRef(item.identity)))
                 item.serialize(graph)
 
-    def accept(self, visitor: Callable[['Identified'], None]):
-        """Implement the visitor pattern by invoking `visitor` on self
-        and all child objects.
+    def traverse(self, func: Callable[['Identified'], None]):
+        """Enable a traversal of this object and all of its children by
+        invoking the passed function on all objects.
         """
-        visitor(self)
+        # Call the function on the children first, then self.
         for object_list in self._owned_objects.values():
             for obj in object_list:
-                obj.accept(visitor)
+                obj.traverse(func)
+        func(self)

--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -1,6 +1,6 @@
 import math
 import posixpath
-from typing import Union, List, Callable
+from typing import Union, List, Callable, Any
 from urllib.parse import urlparse
 
 import rdflib
@@ -208,7 +208,7 @@ class Identified(SBOLObject):
                 graph.add((identity, rdf_prop, rdflib.URIRef(item.identity)))
                 item.serialize(graph)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         message = f'accept is not implemented for {type(self).__qualname__}'
         raise NotImplementedError(message)
 

--- a/sbol3/implementation.py
+++ b/sbol3/implementation.py
@@ -35,6 +35,16 @@ class Implementation(TopLevel):
                                       initial_value=built)
 
     def accept(self, visitor):
+        """Invokes `visit_implementation` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_implementation method
+        :return: Whatever `visitor.visit_implementation` returns
+        :rtype: Any
+
+        """
         visitor.visit_implementation(self)
 
 

--- a/sbol3/implementation.py
+++ b/sbol3/implementation.py
@@ -34,5 +34,8 @@ class Implementation(TopLevel):
         self.built = ReferencedObject(self, SBOL_BUILT, 0, 1,
                                       initial_value=built)
 
+    def accept(self, visitor):
+        visitor.visit_implementation(self)
+
 
 Document.register_builder(SBOL_IMPLEMENTATION, Implementation)

--- a/sbol3/implementation.py
+++ b/sbol3/implementation.py
@@ -1,4 +1,4 @@
-from typing import Union, List
+from typing import Union, List, Any
 
 from . import *
 
@@ -34,7 +34,7 @@ class Implementation(TopLevel):
         self.built = ReferencedObject(self, SBOL_BUILT, 0, 1,
                                       initial_value=built)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_implementation` on `visitor` with `self` as the only
         argument.
 

--- a/sbol3/interaction.py
+++ b/sbol3/interaction.py
@@ -37,6 +37,9 @@ class Interaction(Identified):
                                           initial_value=participations,
                                           type_constraint=Participation)
 
+    def accept(self, visitor):
+        visitor.visit_interaction(self)
+
 
 def build_interaction(identity: str, *, type_uri: str = SBOL_INTERACTION) -> SBOLObject:
     interaction_type = PYSBOL3_MISSING

--- a/sbol3/interaction.py
+++ b/sbol3/interaction.py
@@ -38,6 +38,16 @@ class Interaction(Identified):
                                           type_constraint=Participation)
 
     def accept(self, visitor):
+        """Invokes `visit_interaction` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_interaction method
+        :return: Whatever `visitor.visit_interaction` returns
+        :rtype: Any
+
+        """
         visitor.visit_interaction(self)
 
 

--- a/sbol3/interaction.py
+++ b/sbol3/interaction.py
@@ -1,5 +1,5 @@
 import math
-from typing import List
+from typing import List, Any
 
 from . import *
 
@@ -37,7 +37,7 @@ class Interaction(Identified):
                                           initial_value=participations,
                                           type_constraint=Participation)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_interaction` on `visitor` with `self` as the only
         argument.
 

--- a/sbol3/interface.py
+++ b/sbol3/interface.py
@@ -30,6 +30,9 @@ class Interface(Identified):
                                                0, math.inf,
                                                initial_value=nondirectional)
 
+    def accept(self, visitor):
+        visitor.visit_interface(self)
+
 
 def build_interface(identity: str, *, type_uri: str = SBOL_INTERFACE) -> SBOLObject:
     return Interface(identity=identity, type_uri=type_uri)

--- a/sbol3/interface.py
+++ b/sbol3/interface.py
@@ -1,5 +1,5 @@
 import math
-from typing import List
+from typing import List, Any
 
 from . import *
 
@@ -30,7 +30,7 @@ class Interface(Identified):
                                                0, math.inf,
                                                initial_value=nondirectional)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_interface` on `visitor` with `self` as the only
         argument.
 

--- a/sbol3/interface.py
+++ b/sbol3/interface.py
@@ -31,6 +31,16 @@ class Interface(Identified):
                                                initial_value=nondirectional)
 
     def accept(self, visitor):
+        """Invokes `visit_interface` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_interface method
+        :return: Whatever `visitor.visit_interface` returns
+        :rtype: Any
+
+        """
         visitor.visit_interface(self)
 
 

--- a/sbol3/localsub.py
+++ b/sbol3/localsub.py
@@ -33,6 +33,9 @@ class LocalSubComponent(Feature):
                                      initial_value=locations,
                                      type_constraint=Location)
 
+    def accept(self, visitor):
+        visitor.visit_local_sub_component(self)
+
 
 def build_local_subcomponent(identity: str,
                              *, type_uri: str = SBOL_LOCAL_SUBCOMPONENT) -> SBOLObject:

--- a/sbol3/localsub.py
+++ b/sbol3/localsub.py
@@ -34,6 +34,17 @@ class LocalSubComponent(Feature):
                                      type_constraint=Location)
 
     def accept(self, visitor):
+        """Invokes `visit_local_sub_component` on `visitor` with `self` as the
+        only argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_local_sub_component
+                                method
+        :return: Whatever `visitor.visit_local_sub_component` returns
+        :rtype: Any
+
+        """
         visitor.visit_local_sub_component(self)
 
 

--- a/sbol3/localsub.py
+++ b/sbol3/localsub.py
@@ -1,4 +1,5 @@
 import math
+from typing import Any
 
 from . import *
 # Feature is not exported
@@ -33,7 +34,7 @@ class LocalSubComponent(Feature):
                                      initial_value=locations,
                                      type_constraint=Location)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_local_sub_component` on `visitor` with `self` as the
         only argument.
 

--- a/sbol3/location.py
+++ b/sbol3/location.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Union
+from typing import Union, Any
 
 from . import *
 
@@ -71,7 +71,7 @@ class Range(Location):
             report.addError(self.identity, 'sbol3-11403', message)
         return report
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_range` on `visitor` with `self` as the only
         argument.
 
@@ -128,7 +128,7 @@ class Cut(Location):
             report.addError(self.identity, None, message)
         return report
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_cut` on `visitor` with `self` as the only argument.
 
         :param visitor: The visitor instance
@@ -171,7 +171,7 @@ class EntireSequence(Location):
                          order=order, identity=identity,
                          type_uri=type_uri)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_entire_sequence` on `visitor` with `self` as the
         only argument.
 

--- a/sbol3/location.py
+++ b/sbol3/location.py
@@ -72,6 +72,16 @@ class Range(Location):
         return report
 
     def accept(self, visitor):
+        """Invokes `visit_range` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_range method
+        :return: Whatever `visitor.visit_range` returns
+        :rtype: Any
+
+        """
         visitor.visit_range(self)
 
 
@@ -119,6 +129,14 @@ class Cut(Location):
         return report
 
     def accept(self, visitor):
+        """Invokes `visit_cut` on `visitor` with `self` as the only argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_cut method
+        :return: Whatever `visitor.visit_cut` returns
+        :rtype: Any
+        """
         visitor.visit_cut(self)
 
 
@@ -154,6 +172,17 @@ class EntireSequence(Location):
                          type_uri=type_uri)
 
     def accept(self, visitor):
+        """Invokes `visit_entire_sequence` on `visitor` with `self` as the
+        only argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_entire_sequence
+                                method
+        :return: Whatever `visitor.visit_entire_sequence` returns
+        :rtype: Any
+
+        """
         visitor.visit_entire_sequence(self)
 
 

--- a/sbol3/location.py
+++ b/sbol3/location.py
@@ -71,6 +71,9 @@ class Range(Location):
             report.addError(self.identity, 'sbol3-11403', message)
         return report
 
+    def accept(self, visitor):
+        visitor.visit_range(self)
+
 
 def build_range(identity: str, type_uri: str = SBOL_RANGE):
     """Used by Document to construct a Range when reading an SBOL file.
@@ -115,6 +118,9 @@ class Cut(Location):
             report.addError(self.identity, None, message)
         return report
 
+    def accept(self, visitor):
+        visitor.visit_cut(self)
+
 
 def build_cut(identity: str, type_uri: str = SBOL_CUT):
     """Used by Document to construct a Cut when reading an SBOL file.
@@ -146,6 +152,9 @@ class EntireSequence(Location):
         super().__init__(sequence=sequence, orientation=orientation,
                          order=order, identity=identity,
                          type_uri=type_uri)
+
+    def accept(self, visitor):
+        visitor.visit_entire_sequence(self)
 
 
 def build_entire_sequence(identity: str, type_uri: str = SBOL_ENTIRE_SEQUENCE):

--- a/sbol3/model.py
+++ b/sbol3/model.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Any
 
 from . import *
 
@@ -50,7 +50,7 @@ class Model(TopLevel):
             report.addError(self.identity, None, msg)
         return report
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_model` on `visitor` with `self` as the only
         argument.
 

--- a/sbol3/model.py
+++ b/sbol3/model.py
@@ -50,6 +50,9 @@ class Model(TopLevel):
             report.addError(self.identity, None, msg)
         return report
 
+    def accept(self, visitor):
+        visitor.visit_model(self)
+
 
 def build_model(identity: str, type_uri: str = SBOL_MODEL):
     """Used by Document to construct a Range when reading an SBOL file.

--- a/sbol3/model.py
+++ b/sbol3/model.py
@@ -51,6 +51,16 @@ class Model(TopLevel):
         return report
 
     def accept(self, visitor):
+        """Invokes `visit_model` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_model method
+        :return: Whatever `visitor.visit_model` returns
+        :rtype: Any
+
+        """
         visitor.visit_model(self)
 
 

--- a/sbol3/om_compound.py
+++ b/sbol3/om_compound.py
@@ -70,6 +70,9 @@ class UnitMultiplication(CompoundUnit):
         self.term2 = ReferencedObject(self, OM_HAS_TERM2, 1, 1,
                                       initial_value=term2)
 
+    def accept(self, visitor):
+        visitor.visit_unit_multiplication(self)
+
 
 def build_unit_multiplication(identity: str,
                               *, type_uri: str = OM_UNIT_MULTIPLICATION) -> SBOLObject:
@@ -120,6 +123,9 @@ class UnitDivision(CompoundUnit):
         self.denominator = ReferencedObject(self, OM_HAS_DENOMINATOR, 1, 1,
                                             initial_value=denominator)
 
+    def accept(self, visitor):
+        visitor.visit_unit_division(self)
+
 
 def build_unit_division(identity: str,
                         *, type_uri: str = OM_UNIT_DIVISION) -> SBOLObject:
@@ -169,6 +175,9 @@ class UnitExponentiation(CompoundUnit):
                                      initial_value=base)
         self.exponent = IntProperty(self, OM_HAS_EXPONENT, 1, 1,
                                     initial_value=exponent)
+
+    def accept(self, visitor):
+        visitor.visit_unit_exponentiation(self)
 
 
 def build_unit_exponentiation(identity: str,

--- a/sbol3/om_compound.py
+++ b/sbol3/om_compound.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Union, List
+from typing import Union, List, Any
 
 from . import *
 
@@ -70,7 +70,7 @@ class UnitMultiplication(CompoundUnit):
         self.term2 = ReferencedObject(self, OM_HAS_TERM2, 1, 1,
                                       initial_value=term2)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_unit_multiplication` on `visitor` with `self` as the
         only argument.
 
@@ -134,7 +134,7 @@ class UnitDivision(CompoundUnit):
         self.denominator = ReferencedObject(self, OM_HAS_DENOMINATOR, 1, 1,
                                             initial_value=denominator)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_unit_division` on `visitor` with `self` as the only
         argument.
 
@@ -197,7 +197,7 @@ class UnitExponentiation(CompoundUnit):
         self.exponent = IntProperty(self, OM_HAS_EXPONENT, 1, 1,
                                     initial_value=exponent)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_unit_exponentiation` on `visitor` with `self` as the
         only argument.
 

--- a/sbol3/om_compound.py
+++ b/sbol3/om_compound.py
@@ -71,6 +71,17 @@ class UnitMultiplication(CompoundUnit):
                                       initial_value=term2)
 
     def accept(self, visitor):
+        """Invokes `visit_unit_multiplication` on `visitor` with `self` as the
+        only argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_unit_multiplication
+                                method
+        :return: Whatever `visitor.visit_unit_multiplication` returns
+        :rtype: Any
+
+        """
         visitor.visit_unit_multiplication(self)
 
 
@@ -124,6 +135,16 @@ class UnitDivision(CompoundUnit):
                                             initial_value=denominator)
 
     def accept(self, visitor):
+        """Invokes `visit_unit_division` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_unit_division method
+        :return: Whatever `visitor.visit_unit_division` returns
+        :rtype: Any
+
+        """
         visitor.visit_unit_division(self)
 
 
@@ -177,6 +198,17 @@ class UnitExponentiation(CompoundUnit):
                                     initial_value=exponent)
 
     def accept(self, visitor):
+        """Invokes `visit_unit_exponentiation` on `visitor` with `self` as the
+        only argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_unit_exponentiation
+                                method
+        :return: Whatever `visitor.visit_unit_exponentiation` returns
+        :rtype: Any
+
+        """
         visitor.visit_unit_exponentiation(self)
 
 

--- a/sbol3/om_prefix.py
+++ b/sbol3/om_prefix.py
@@ -92,6 +92,9 @@ class SIPrefix(Prefix):
                          description=description, derived_from=derived_from,
                          generated_by=generated_by, measures=measures)
 
+    def accept(self, visitor):
+        visitor.visit_si_prefix(self)
+
 
 def build_si_prefix(identity: str, *, type_uri: str = OM_SI_PREFIX) -> SBOLObject:
     obj = SIPrefix(identity=identity, type_uri=type_uri,
@@ -136,6 +139,9 @@ class BinaryPrefix(Prefix):
                          attachments=attachments, name=name,
                          description=description, derived_from=derived_from,
                          generated_by=generated_by, measures=measures)
+
+    def accept(self, visitor):
+        visitor.visit_binary_prefix(self)
 
 
 def build_binary_prefix(identity: str,

--- a/sbol3/om_prefix.py
+++ b/sbol3/om_prefix.py
@@ -1,6 +1,6 @@
 import abc
 import math
-from typing import List
+from typing import List, Any
 
 from . import *
 
@@ -92,7 +92,7 @@ class SIPrefix(Prefix):
                          description=description, derived_from=derived_from,
                          generated_by=generated_by, measures=measures)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_si_prefix` on `visitor` with `self` as the only
         argument.
 
@@ -150,7 +150,7 @@ class BinaryPrefix(Prefix):
                          description=description, derived_from=derived_from,
                          generated_by=generated_by, measures=measures)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_binary_prefix` on `visitor` with `self` as the only
         argument.
 

--- a/sbol3/om_prefix.py
+++ b/sbol3/om_prefix.py
@@ -93,6 +93,16 @@ class SIPrefix(Prefix):
                          generated_by=generated_by, measures=measures)
 
     def accept(self, visitor):
+        """Invokes `visit_si_prefix` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_si_prefix method
+        :return: Whatever `visitor.visit_si_prefix` returns
+        :rtype: Any
+
+        """
         visitor.visit_si_prefix(self)
 
 
@@ -141,6 +151,16 @@ class BinaryPrefix(Prefix):
                          generated_by=generated_by, measures=measures)
 
     def accept(self, visitor):
+        """Invokes `visit_binary_prefix` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_binary_prefix method
+        :return: Whatever `visitor.visit_binary_prefix` returns
+        :rtype: Any
+
+        """
         visitor.visit_binary_prefix(self)
 
 

--- a/sbol3/om_unit.py
+++ b/sbol3/om_unit.py
@@ -1,6 +1,6 @@
 import abc
 import math
-from typing import Union, List
+from typing import Union, List, Any
 
 from . import *
 from .om_prefix import Prefix
@@ -73,7 +73,7 @@ class Measure(CustomIdentified):
         self.unit = URIProperty(self, OM_HAS_UNIT, 1, 1,
                                 initial_value=unit)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_measure` on `visitor` with `self` as the only
         argument.
 
@@ -136,7 +136,7 @@ class SingularUnit(Unit):
         self.factor = FloatProperty(self, OM_HAS_FACTOR, 0, 1,
                                     initial_value=factor)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_singular_unit` on `visitor` with `self` as the only
         argument.
 
@@ -200,7 +200,7 @@ class PrefixedUnit(Unit):
         self.prefix = ReferencedObject(self, OM_HAS_PREFIX, 1, 1,
                                        initial_value=prefix)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_prefixed_unit` on `visitor` with `self` as the only
         argument.
 

--- a/sbol3/om_unit.py
+++ b/sbol3/om_unit.py
@@ -74,6 +74,16 @@ class Measure(CustomIdentified):
                                 initial_value=unit)
 
     def accept(self, visitor):
+        """Invokes `visit_measure` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_measure method
+        :return: Whatever `visitor.visit_measure` returns
+        :rtype: Any
+
+        """
         visitor.visit_measure(self)
 
 
@@ -127,6 +137,16 @@ class SingularUnit(Unit):
                                     initial_value=factor)
 
     def accept(self, visitor):
+        """Invokes `visit_singular_unit` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_singular_unit method
+        :return: Whatever `visitor.visit_singular_unit` returns
+        :rtype: Any
+
+        """
         visitor.visit_singular_unit(self)
 
 
@@ -181,6 +201,16 @@ class PrefixedUnit(Unit):
                                        initial_value=prefix)
 
     def accept(self, visitor):
+        """Invokes `visit_prefixed_unit` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_prefixed_unit method
+        :return: Whatever `visitor.visit_prefixed_unit` returns
+        :rtype: Any
+
+        """
         visitor.visit_prefixed_unit(self)
 
 

--- a/sbol3/om_unit.py
+++ b/sbol3/om_unit.py
@@ -73,6 +73,9 @@ class Measure(CustomIdentified):
         self.unit = URIProperty(self, OM_HAS_UNIT, 1, 1,
                                 initial_value=unit)
 
+    def accept(self, visitor):
+        visitor.visit_measure(self)
+
 
 def build_measure(identity: str, *, type_uri: str = OM_MEASURE) -> SBOLObject:
     missing = PYSBOL3_MISSING
@@ -122,6 +125,9 @@ class SingularUnit(Unit):
                                      initial_value=unit)
         self.factor = FloatProperty(self, OM_HAS_FACTOR, 0, 1,
                                     initial_value=factor)
+
+    def accept(self, visitor):
+        visitor.visit_singular_unit(self)
 
 
 def build_singular_unit(identity: str,
@@ -173,6 +179,9 @@ class PrefixedUnit(Unit):
                                      initial_value=unit)
         self.prefix = ReferencedObject(self, OM_HAS_PREFIX, 1, 1,
                                        initial_value=prefix)
+
+    def accept(self, visitor):
+        visitor.visit_prefixed_unit(self)
 
 
 def build_prefixed_unit(identity: str,

--- a/sbol3/participation.py
+++ b/sbol3/participation.py
@@ -1,4 +1,5 @@
 import math
+from typing import Any
 
 from . import *
 from .typing import *
@@ -37,7 +38,7 @@ class Participation(Identified):
             report.addError(self.identity, None, message)
         return report
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_participation` on `visitor` with `self` as the only
         argument.
 

--- a/sbol3/participation.py
+++ b/sbol3/participation.py
@@ -38,6 +38,16 @@ class Participation(Identified):
         return report
 
     def accept(self, visitor):
+        """Invokes `visit_participation` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_participation method
+        :return: Whatever `visitor.visit_participation` returns
+        :rtype: Any
+
+        """
         visitor.visit_participation(self)
 
 

--- a/sbol3/participation.py
+++ b/sbol3/participation.py
@@ -37,6 +37,9 @@ class Participation(Identified):
             report.addError(self.identity, None, message)
         return report
 
+    def accept(self, visitor):
+        visitor.visit_participation(self)
+
 
 def build_participation(identity: str,
                         *, type_uri: str = SBOL_PARTCIPATION) -> SBOLObject:

--- a/sbol3/provenance.py
+++ b/sbol3/provenance.py
@@ -1,6 +1,6 @@
 import datetime
 import math
-from typing import Union, List
+from typing import Union, List, Any
 
 from . import *
 
@@ -34,7 +34,7 @@ class Usage(CustomIdentified):
         self.roles = URIProperty(self, PROV_ROLES, 0, math.inf,
                                  initial_value=roles)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_usage` on `visitor` with `self` as the only
         argument.
 
@@ -80,7 +80,7 @@ class Agent(CustomTopLevel):
                          description=description, derived_from=derived_from,
                          generated_by=generated_by, measures=measures)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_agent` on `visitor` with `self` as the only
         argument.
 
@@ -118,7 +118,7 @@ class Plan(CustomTopLevel):
                          description=description, derived_from=derived_from,
                          generated_by=generated_by, measures=measures)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_plan` on `visitor` with `self` as the only argument.
 
         :param visitor: The visitor instance
@@ -160,7 +160,7 @@ class Association(CustomIdentified):
         self.agent = ReferencedObject(self, PROV_AGENTS, 1, 1,
                                       initial_value=agent)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_association` on `visitor` with `self` as the only
         argument.
 
@@ -237,7 +237,7 @@ class Activity(CustomTopLevel):
                                        initial_value=association,
                                        type_constraint=Association)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_activity` on `visitor` with `self` as the only
         argument.
 

--- a/sbol3/provenance.py
+++ b/sbol3/provenance.py
@@ -35,6 +35,16 @@ class Usage(CustomIdentified):
                                  initial_value=roles)
 
     def accept(self, visitor):
+        """Invokes `visit_usage` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_usage method
+        :return: Whatever `visitor.visit_usage` returns
+        :rtype: Any
+
+        """
         visitor.visit_usage(self)
 
 
@@ -71,6 +81,16 @@ class Agent(CustomTopLevel):
                          generated_by=generated_by, measures=measures)
 
     def accept(self, visitor):
+        """Invokes `visit_agent` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_agent method
+        :return: Whatever `visitor.visit_agent` returns
+        :rtype: Any
+
+        """
         visitor.visit_agent(self)
 
 
@@ -99,6 +119,14 @@ class Plan(CustomTopLevel):
                          generated_by=generated_by, measures=measures)
 
     def accept(self, visitor):
+        """Invokes `visit_plan` on `visitor` with `self` as the only argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_plan method
+        :return: Whatever `visitor.visit_plan` returns
+        :rtype: Any
+        """
         visitor.visit_plan(self)
 
 
@@ -133,6 +161,16 @@ class Association(CustomIdentified):
                                       initial_value=agent)
 
     def accept(self, visitor):
+        """Invokes `visit_association` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_association method
+        :return: Whatever `visitor.visit_association` returns
+        :rtype: Any
+
+        """
         visitor.visit_association(self)
 
 
@@ -200,6 +238,16 @@ class Activity(CustomTopLevel):
                                        type_constraint=Association)
 
     def accept(self, visitor):
+        """Invokes `visit_activity` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_activity method
+        :return: Whatever `visitor.visit_activity` returns
+        :rtype: Any
+
+        """
         visitor.visit_activity(self)
 
 

--- a/sbol3/provenance.py
+++ b/sbol3/provenance.py
@@ -34,6 +34,9 @@ class Usage(CustomIdentified):
         self.roles = URIProperty(self, PROV_ROLES, 0, math.inf,
                                  initial_value=roles)
 
+    def accept(self, visitor):
+        visitor.visit_usage(self)
+
 
 def build_usage(identity: str, *, type_uri: str = PROV_USAGE) -> SBOLObject:
     obj = Usage(entity=PYSBOL3_MISSING, identity=identity, type_uri=type_uri)
@@ -67,6 +70,9 @@ class Agent(CustomTopLevel):
                          description=description, derived_from=derived_from,
                          generated_by=generated_by, measures=measures)
 
+    def accept(self, visitor):
+        visitor.visit_agent(self)
+
 
 Document.register_builder(PROV_AGENT, Agent)
 
@@ -91,6 +97,9 @@ class Plan(CustomTopLevel):
                          attachments=attachments, name=name,
                          description=description, derived_from=derived_from,
                          generated_by=generated_by, measures=measures)
+
+    def accept(self, visitor):
+        visitor.visit_plan(self)
 
 
 Document.register_builder(PROV_PLAN, Plan)
@@ -122,6 +131,9 @@ class Association(CustomIdentified):
                                      initial_value=plan)
         self.agent = ReferencedObject(self, PROV_AGENTS, 1, 1,
                                       initial_value=agent)
+
+    def accept(self, visitor):
+        visitor.visit_association(self)
 
 
 def build_association(identity: str,
@@ -186,6 +198,9 @@ class Activity(CustomTopLevel):
                                        0, math.inf,
                                        initial_value=association,
                                        type_constraint=Association)
+
+    def accept(self, visitor):
+        visitor.visit_activity(self)
 
 
 Document.register_builder(PROV_ACTIVITY, Activity)

--- a/sbol3/seqfeat.py
+++ b/sbol3/seqfeat.py
@@ -1,4 +1,5 @@
 import math
+from typing import Any
 
 from . import *
 # Feature is not exported
@@ -26,7 +27,7 @@ class SequenceFeature(Feature):
                                               type_constraint=Location,
                                               initial_value=locations)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_sequence_feature` on `visitor` with `self` as the
         only argument.
 

--- a/sbol3/seqfeat.py
+++ b/sbol3/seqfeat.py
@@ -27,6 +27,16 @@ class SequenceFeature(Feature):
                                               initial_value=locations)
 
     def accept(self, visitor):
+        """Invokes `visit_sequence_feature` on `visitor` with `self` as the
+        only argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_sequence_feature method
+        :return: Whatever `visitor.visit_sequence_feature` returns
+        :rtype: Any
+
+        """
         visitor.visit_sequence_feature(self)
 
 

--- a/sbol3/seqfeat.py
+++ b/sbol3/seqfeat.py
@@ -26,6 +26,9 @@ class SequenceFeature(Feature):
                                               type_constraint=Location,
                                               initial_value=locations)
 
+    def accept(self, visitor):
+        visitor.visit_sequence_feature(self)
+
 
 def build_sequence_feature(identity: str,
                            *, type_uri: str = SBOL_SEQUENCE_FEATURE) -> SBOLObject:

--- a/sbol3/sequence.py
+++ b/sbol3/sequence.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Any
 
 from . import *
 
@@ -39,7 +39,7 @@ class Sequence(TopLevel):
             report.addWarning(self.identity, 'sbol3-10505', message)
         return report
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_sequence` on `visitor` with `self` as the only
         argument.
 

--- a/sbol3/sequence.py
+++ b/sbol3/sequence.py
@@ -40,6 +40,16 @@ class Sequence(TopLevel):
         return report
 
     def accept(self, visitor):
+        """Invokes `visit_sequence` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_sequence method
+        :return: Whatever `visitor.visit_sequence` returns
+        :rtype: Any
+
+        """
         visitor.visit_sequence(self)
 
 

--- a/sbol3/sequence.py
+++ b/sbol3/sequence.py
@@ -39,5 +39,8 @@ class Sequence(TopLevel):
             report.addWarning(self.identity, 'sbol3-10505', message)
         return report
 
+    def accept(self, visitor):
+        visitor.visit_sequence(self)
+
 
 Document.register_builder(SBOL_SEQUENCE, Sequence)

--- a/sbol3/subcomponent.py
+++ b/sbol3/subcomponent.py
@@ -43,6 +43,16 @@ class SubComponent(Feature):
                                      type_constraint=Location)
 
     def accept(self, visitor):
+        """Invokes `visit_sub_component` on `visitor` with `self` as the only
+        argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_sub_component method
+        :return: Whatever `visitor.visit_sub_component` returns
+        :rtype: Any
+
+        """
         visitor.visit_sub_component(self)
 
 

--- a/sbol3/subcomponent.py
+++ b/sbol3/subcomponent.py
@@ -1,5 +1,5 @@
 import math
-from typing import Union, List
+from typing import Union, List, Any
 
 from . import *
 # Feature is not exported
@@ -42,7 +42,7 @@ class SubComponent(Feature):
                                      initial_value=locations,
                                      type_constraint=Location)
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_sub_component` on `visitor` with `self` as the only
         argument.
 

--- a/sbol3/subcomponent.py
+++ b/sbol3/subcomponent.py
@@ -42,6 +42,9 @@ class SubComponent(Feature):
                                      initial_value=locations,
                                      type_constraint=Location)
 
+    def accept(self, visitor):
+        visitor.visit_sub_component(self)
+
 
 def build_subcomponent(identity: str, type_uri: str = SBOL_SUBCOMPONENT) -> Identified:
     """Used by Document to construct a SubComponent when reading an SBOL file.

--- a/sbol3/toplevel.py
+++ b/sbol3/toplevel.py
@@ -100,7 +100,7 @@ class TopLevel(Identified):
         obj.document = None
 
         # Erase the identity and display_id of the entire tree
-        obj.accept(make_erase_identity_visitor(identity_map))
+        obj.traverse(make_erase_identity_traverser(identity_map))
 
         # Now remove and re-add all child objects to update
         # their identities
@@ -108,25 +108,25 @@ class TopLevel(Identified):
 
         # TODO: Now remap any properties that reference old
         #       identities in the identity_map
-        obj.accept(make_update_references_visitor(identity_map))
+        obj.traverse(make_update_references_traverser(identity_map))
         return obj
 
 
-def make_erase_identity_visitor(identity_map: Dict[str, Identified])\
+def make_erase_identity_traverser(identity_map: Dict[str, Identified])\
         -> Callable[[Identified], None]:
-    def erase_identity_visitor(x):
+    def erase_identity_traverser(x):
         if isinstance(x, TopLevel):
             return
         identity_map[x.identity] = x
         x._identity = None
         x._display_id = None
         x.document = None
-    return erase_identity_visitor
+    return erase_identity_traverser
 
 
-def make_update_references_visitor(identity_map: Dict[str, Identified])\
+def make_update_references_traverser(identity_map: Dict[str, Identified])\
         -> Callable[[Identified], None]:
-    def update_references_visitor(x):
+    def update_references_traverser(x):
         # Use the identity map to update references.
         # References to objects outside of the object
         # being cloned will be left as is.
@@ -146,4 +146,4 @@ def make_update_references_visitor(identity_map: Dict[str, Identified])\
                     # Hacky? yes, and it seems to work
                     constructor = type(items[i])
                     items[i] = constructor(new_reference)
-    return update_references_visitor
+    return update_references_traverser

--- a/sbol3/varcomp.py
+++ b/sbol3/varcomp.py
@@ -66,6 +66,16 @@ class VariableFeature(Identified):
         return report
 
     def accept(self, visitor):
+        """Invokes `visit_variable_feature` on `visitor` with `self` as the
+        only argument.
+
+        :param visitor: The visitor instance
+        :type visitor: Any
+        :raises AttributeError: If visitor lacks a visit_variable_feature method
+        :return: Whatever `visitor.visit_variable_feature` returns
+        :rtype: Any
+
+        """
         visitor.visit_variable_feature(self)
 
 

--- a/sbol3/varcomp.py
+++ b/sbol3/varcomp.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, Union
+from typing import List, Union, Any
 
 from . import *
 
@@ -65,7 +65,7 @@ class VariableFeature(Identified):
             report.addError(self.identity, None, message)
         return report
 
-    def accept(self, visitor):
+    def accept(self, visitor: Any) -> Any:
         """Invokes `visit_variable_feature` on `visitor` with `self` as the
         only argument.
 

--- a/sbol3/varcomp.py
+++ b/sbol3/varcomp.py
@@ -65,6 +65,9 @@ class VariableFeature(Identified):
             report.addError(self.identity, None, message)
         return report
 
+    def accept(self, visitor):
+        visitor.visit_variable_feature(self)
+
 
 def build_variable_feature(identity: str, type_uri: str = SBOL_VARIABLE_FEATURE):
     """Used by Document to construct a VariableFeature when reading an SBOL file.

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -215,31 +215,31 @@ class TestDocument(unittest.TestCase):
         found = doc.find_all(lambda obj: isinstance(obj, sbol3.Participation))
         self.assertEqual(11, len(found))
 
-    def test_visit_all(self):
-        visited_list = []
+    def test_traverse_all(self):
+        traversed_list = []
 
-        def my_visitor(obj: sbol3.Identified):
-            visited_list.append(obj)
+        def my_traverser(obj: sbol3.Identified):
+            traversed_list.append(obj)
         file = os.path.join(SBOL3_LOCATION, 'multicellular',
                             'multicellular.nt')
         doc = sbol3.Document()
         doc.read(file)
-        doc.accept(my_visitor)
-        self.assertEqual(75, len(visited_list))
+        doc.traverse(my_traverser)
+        self.assertEqual(75, len(traversed_list))
 
-    def test_visit_participations(self):
-        # Visit all and only the participations
-        visited_list = []
+    def test_traverse_participations(self):
+        # Traverse all and only the participations
+        traversed_list = []
 
-        def my_visitor(obj: sbol3.Identified):
+        def my_traverser(obj: sbol3.Identified):
             if isinstance(obj, sbol3.Participation):
-                visited_list.append(obj)
+                traversed_list.append(obj)
         file = os.path.join(SBOL3_LOCATION, 'multicellular',
                             'multicellular.nt')
         doc = sbol3.Document()
         doc.read(file)
-        doc.accept(my_visitor)
-        self.assertEqual(11, len(visited_list))
+        doc.traverse(my_traverser)
+        self.assertEqual(11, len(traversed_list))
 
     def test_builder_lookup(self):
         # Test looking up a builder function

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -79,11 +79,16 @@ class TestModule(unittest.TestCase):
                                 'https://example.com/fake']
         }
         skip_list = [sbol3.Identified, sbol3.Feature, sbol3.Location]
+        abstract_list = [sbol3.CustomIdentified, sbol3.TopLevel,
+                         sbol3.CustomTopLevel]
         for name in dir(sbol3):
             item = getattr(sbol3, name)
             if not isinstance(item, type):
                 continue
             if issubclass(item, sbol3.TopLevel):
+                if item not in abstract_list:
+                    self.assertTrue(hasattr(item, 'accept'),
+                                    f'{str(item)} has no accept attribute')
                 continue
             if not issubclass(item, sbol3.Identified):
                 continue
@@ -98,6 +103,12 @@ class TestModule(unittest.TestCase):
                 self.fail('Unable to construct sbol3.%s: %s' % (name, e))
             except sbol3.ValidationError as e:
                 self.fail('Constructed invalid sbol3.%s: %s' % (name, e))
+            if item in abstract_list:
+                # Skip over abstract classes when checking for the
+                # accept method
+                continue
+            self.assertTrue(hasattr(item, 'accept'),
+                            f'{str(item)} has no accept attribute')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Implement the visitor pattern using objects, not functions (Fixes #241)
* The traversal algorithm is left to the visitor so that accept methods do not determine the order in which elements are visited (Fixes #242)
* Use snake case names for `visit_type` methods to conform to python method naming standards (Fixes #239)
  * For example, `SubComponent.accept` invokes `visitor.visit_sub_component`
