### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         # Default builds are on Ubuntu
         os: [ubuntu-latest]
-        python-version: [3.6, 3.8, 3.9, pypy3]
+        python-version: [3.7, 3.8, 3.9, pypy-3.7]
         include:
           # Also test on macOS and Windows using latest Python 3
           - os: macos-latest

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ missing features.
 
 ## Installation
 
-Use pip to install the library:
+pySBOL3 requires [Python 3.7](https://www.python.org) or newer.
+
+Use `pip` (or `pip3`) to install the library:
 
 ```
 pip install sbol3

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 pySBOL3 is a pure `Python <https://www.python.org>`_ package and is
 available on any platform that supports Python 3.  pySBOL3 requires
-Python 3.6 or higher, and can be installed using using `pip
+Python version 3.7 or higher, and can be installed using using `pip
 <https://pypi.org/project/pip/>`_
 
 .. note:: Python 2 is not supported.

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -8,7 +8,7 @@ implements `SBOL 3.0
 <https://sbolstandard.org/wp-content/uploads/2020/04/SBOL3.0specification.pdf>`_. The
 module provides an API to work with SBOL objects, and the ability to
 read and write SBOL version 3 files in a variety of RDF formats.
-pySBOL3 supports Python 3.6 or later. pySBOL3 does not support
+pySBOL3 supports Python 3.7 or later. pySBOL3 does not support
 Python 2. pySBOL3 is made freely available under the `Apache 2.0
 license <https://www.apache.org/licenses/>`_.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(name='sbol3',
       version='1.0a10',
       description='Python implementation of SBOL 3 standard',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       url='https://github.com/SynBioDex/pySBOL3',
       author='Bryan Bartley',
       author_email='editors@sbolstandard.org',


### PR DESCRIPTION
Python 3.6 will no longer be supported in a few months. Upcoming changes to validation are incompatible with Python 3.6. Drop support for Python 3.6 to pave the way for SHACL-based validation.

Closes #246 