### PR TITLE
Add a default namespace

### DIFF
--- a/sbol3/constants.py
+++ b/sbol3/constants.py
@@ -141,6 +141,8 @@ SBOL_ZERO_OR_ONE = SBOL3_NS + 'zeroOrOne'
 PYSBOL3_NS = 'https://github.com/synbiodex/pysbol3#'
 PYSBOL3_MISSING = PYSBOL3_NS + 'missing'
 
+# Used if no namespace has been set via set_namespace()
+PYSBOL3_DEFAULT_NAMESPACE = 'http://sbols.org/unspecified_namespace/'
 
 # ----------
 # Provenance terms

--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -1,5 +1,6 @@
 import posixpath
 import uuid
+import warnings
 from collections import defaultdict
 from urllib.parse import urlparse
 from typing import Dict, Callable, Optional
@@ -65,9 +66,10 @@ class SBOLObject:
         # Not a URL or a UUID, so append to the namespace
         base_uri = get_namespace()
         if base_uri is None:
-            msg = 'No default namespace available.'
-            msg += ' Use set_namespace() to set one.'
-            raise NamespaceError(msg)
+            # See https://github.com/SynBioDex/pySBOL3/issues/254
+            warnings.warn('Using a default namespace.'
+                          ' To set a namespace use set_namespace()')
+            base_uri = PYSBOL3_DEFAULT_NAMESPACE
         if base_uri.endswith('#'):
             return base_uri + name
         else:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -26,12 +26,28 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(base_uri, sbol3.get_namespace())
 
     def test_no_namespace(self):
+        # This test requires that no objects have been created without
+        # a namespace set. The warning only triggers on the first such
+        # creation. There is probably a way to reset the triggering of
+        # warnings if we need that in the future.
+        #
         # Make sure there is no default namespace
         self.assertEqual(None, sbol3.get_namespace())
-        # Make sure that creating an object with a display_id
-        # and no default namespace raises an exception
-        with self.assertRaises(sbol3.NamespaceError):
-            c = sbol3.Component('c1', sbol3.SBO_DNA)
+        # Make sure creation without a namespace generates a warning
+        display_id = 'c1'
+        with self.assertWarns(UserWarning) as cm:
+            c = sbol3.Component(display_id, sbol3.SBO_DNA)
+        # We expect the warning to come from object.py. Update this if
+        # the logic changes.
+        self.assertIn('object.py', cm.filename)
+        # We expect the default namespace to appear in the identity
+        self.assertIn(sbol3.PYSBOL3_DEFAULT_NAMESPACE, c.identity)
+        # We expect the default namespace at the beginning of the identity
+        self.assertTrue(c.identity.startswith(sbol3.PYSBOL3_DEFAULT_NAMESPACE))
+        # We expect the display_id to appear in the identity
+        self.assertIn(display_id, c.identity)
+        # We expect the display_id to be at the end of the identity
+        self.assertTrue(c.identity.endswith(display_id))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Return to having a default namespace to make it easier for new users
to get started. Issue a warning if the default namespace is used. By
default the warning will be shown once on the first use and will not
appear on subsequent uses of a default namespace.

Closes #254 