### PR TITLE
Fix ValueError parsing pySHACL results

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -387,8 +387,8 @@ class Document:
         sh_result_severity = shacl_ns.resultSeverity
         sh_warning = shacl_ns.Warning
         sh_violation = shacl_ns.Violation
-        for shacl_report, in shacl_graph.subjects(rdflib.RDF.type,
-                                                  shacl_ns.ValidationReport):
+        for shacl_report in shacl_graph.subjects(rdflib.RDF.type,
+                                                 shacl_ns.ValidationReport):
             for result in shacl_graph.objects(shacl_report, shacl_ns.result):
                 object_id = shacl_graph.value(result, shacl_ns.focusNode)
                 message = shacl_graph.value(result, shacl_ns.resultMessage)

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -193,6 +193,30 @@ class TestDocument(unittest.TestCase):
         # We should find the validation issue in the Range
         self.assertEqual(1, len(report))
 
+    def test_validate_invalid_doc(self):
+        # See https://github.com/SynBioDex/pySBOL3/issues/257
+        # This should return an error from the shacl validation
+        doc = sbol3.Document()
+        test_path = os.path.join(SBOL3_LOCATION, 'multicellular',
+                                 'multicellular.nt')
+        doc.read(test_path)
+        report = doc.validate()
+        # Confirm that the original document is valid
+        self.assertEqual(0, len(report))
+        # Now modify an object to be invalid
+        uri = 'https://sbolstandard.org/examples/rbs_luxR'
+        c = doc.find(uri)
+        self.assertIsNotNone(c)
+        c._properties[sbol3.SBOL_TYPE] = []
+        report = doc.validate()
+        # Confirm that the modified document is not valid
+        #
+        # The lack of a component.type is a violation that should be
+        # detected by the shacl validation. This currently causes 2
+        # validation errors, one for too few values for the type property,
+        # and the other for less than 1 value on the type property.
+        self.assertEqual(2, len(report))
+
     def test_find_all(self):
         test_files = {
             os.path.join(SBOL3_LOCATION, 'entity', 'model',


### PR DESCRIPTION
Add a unit test to exercise the code in question and then fix the parsing of the SHACL output graph.

Fixes #257 
