### PR TITLE
Set namespace when default is used

### DIFF
--- a/sbol3/toplevel.py
+++ b/sbol3/toplevel.py
@@ -34,7 +34,7 @@ class TopLevel(Identified):
                          derived_from=derived_from, generated_by=generated_by,
                          measures=measures)
         if namespace is None:
-            namespace = TopLevel.default_namespace(namespace, identity)
+            namespace = TopLevel.default_namespace(namespace, self.identity)
         self.namespace = URIProperty(self, SBOL_NAMESPACE, 1, 1,
                                      initial_value=namespace)
         self.attachments = ReferencedObject(self, SBOL_HAS_ATTACHMENT, 0, math.inf,

--- a/test/test_toplevel.py
+++ b/test/test_toplevel.py
@@ -1,0 +1,24 @@
+import posixpath
+import unittest
+
+import sbol3
+
+class MyTestCase(unittest.TestCase):
+
+    def setUp(self) -> None:
+        sbol3.set_defaults()
+
+    def tearDown(self) -> None:
+        sbol3.set_defaults()
+
+    def test_default_namespace(self):
+        # See https://github.com/SynBioDex/pySBOL3/issues/263
+        display_id = 'foo'
+        c = sbol3.Component(display_id, sbol3.SBO_DNA)
+        self.assertIsNotNone(c.namespace)
+        self.assertTrue(c.identity.endswith(display_id))
+        self.assertEqual(c.identity, posixpath.join(c.namespace, display_id))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_toplevel.py
+++ b/test/test_toplevel.py
@@ -3,6 +3,7 @@ import unittest
 
 import sbol3
 
+
 class MyTestCase(unittest.TestCase):
 
     def setUp(self) -> None:


### PR DESCRIPTION
Fix a bug that left namespace None when the default namespace was used
to form the identity.

Fixes #263 