### PR TITLE
Add scripts to support cross-library testing

### DIFF
--- a/examples/rdf-compare.py
+++ b/examples/rdf-compare.py
@@ -1,0 +1,78 @@
+import argparse
+import logging
+import pathlib
+
+import rdflib.util
+import rdflib.compare
+
+# Compare two RDF files or two parallel RDF directory trees
+#
+# This is used to compare SBOL3 files without using pySBOL3
+# in order to determine if the files contain the same triples.
+# If any files differ the differences are logged at WARNING level.
+
+
+def parse_args(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('in1', metavar='INPUT_1')
+    parser.add_argument('in2', metavar='INPUT_2')
+    parser.add_argument('-d', '--debug', action='store_true')
+    args = parser.parse_args(args)
+    return args
+
+
+def init_logging(debug=False):
+    msg_format = '%(asctime)s|%(levelname)s|%(message)s'
+    date_format = '%Y-%m-%dT%H:%M:%S%z'
+    level = logging.INFO
+    if debug:
+        level = logging.DEBUG
+    logging.basicConfig(format=msg_format, datefmt=date_format, level=level)
+
+
+def compare_files(file1, file2):
+    # Now compare the graphs in RDF
+    g1 = rdflib.Graph()
+    g1.load(file1.as_posix(), format=rdflib.util.guess_format(file1.as_posix()))
+    iso1 = rdflib.compare.to_isomorphic(g1)
+    g2 = rdflib.Graph()
+    g2.load(file2.as_posix(), format=rdflib.util.guess_format(file2.as_posix()))
+    iso2 = rdflib.compare.to_isomorphic(g2)
+    rdf_diff = rdflib.compare.graph_diff(iso1, iso2)
+    if rdf_diff[1] or rdf_diff[2]:
+        logging.warning('Detected %d different RDF triples in %s' %
+                        (len(rdf_diff[1]) + len(rdf_diff[2]), file1))
+        for stmt in rdf_diff[1]:
+            logging.warning('Only in %s: %r', file1, stmt)
+        for stmt in rdf_diff[2]:
+            logging.warning('Only in %s: %r', file2, stmt)
+
+
+def compare_tree(dir1, dir2):
+    """Compare all the files in the two directory trees.
+    """
+    # iterate over all the files in dir1
+    for path1 in dir1.glob('**/*'):
+        if not path1.is_file():
+            continue
+        logging.debug(path1)
+        path2 = dir2 / path1.relative_to(dir1)
+        compare_files(path1, path2)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    # Init logging
+    init_logging(args.debug)
+    logging.debug('Starting')
+    in1 = pathlib.Path(args.in1)
+    in2 = pathlib.Path(args.in2)
+    if in1.is_dir():
+        compare_tree(in1, in2)
+    else:
+        compare_files(in1, in2)
+    logging.debug('Done')
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/roundtrip.py
+++ b/examples/roundtrip.py
@@ -1,0 +1,65 @@
+import argparse
+import logging
+import pathlib
+
+import rdflib.util
+
+import sbol3
+
+# Round trip a directory tree of SBOL3 files, creating a parallel tree
+# containing the output files.
+
+
+def parse_args(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("in_dir", metavar="INPUT_DIR")
+    parser.add_argument("out_dir", metavar="OUTPUT_DIR")
+    parser.add_argument('-d', '--debug', action='store_true')
+    parser.add_argument('-e', '--extension', metavar="FILE_EXTENSION",
+                        default='ttl')
+    parser.add_argument('-v', '--validate', action='store_true')
+    args = parser.parse_args(args)
+    return args
+
+
+def init_logging(debug=False):
+    msg_format = '%(asctime)s|%(levelname)s|%(message)s'
+    date_format = '%Y-%m-%dT%H:%M:%S%z'
+    level = logging.INFO
+    if debug:
+        level = logging.DEBUG
+    logging.basicConfig(format=msg_format, datefmt=date_format, level=level)
+
+
+def round_trip_file(in_file, out_file, validate=False):
+    # Determine RDF file format
+    file_format = rdflib.util.guess_format(in_file)
+    doc = sbol3.Document()
+    logging.info(f'Reading {in_file}')
+    doc.read(str(in_file), file_format=file_format)
+    if validate:
+        report = doc.validate()
+        if report:
+            logging.warning(f'Found {len(report)} validation errors')
+    logging.info(f'Writing {out_file}')
+    doc.write(str(out_file), file_format=file_format)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    # Init logging
+    init_logging(args.debug)
+    logging.debug('Starting')
+    root_dir = pathlib.Path(args.in_dir)
+    out_dir = pathlib.Path(args.out_dir)
+    for in_file in root_dir.rglob(f'*.{args.extension}'):
+        # Determine output file
+        out_file = out_dir / in_file.relative_to(root_dir)
+        # Create parent directories of output file
+        out_file.parent.mkdir(parents=True, exist_ok=True)
+        round_trip_file(in_file, out_file, validate=args.validate)
+    logging.debug('Done')
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [pycodestyle]
-# SBOL code should ideally not exceed 79 characters per line.
-# However, the style checker will not penalize small infractions.
-# Therefore, any line up to 89 characters is acceptable.
-max-line-length = 89
+# SBOL code should fit on a 120 character wide display. Yes, it's an
+# arbitrary limit. It takes into account modern displays, while not
+# allowing developers to wildly exceed reasonable limits. Not everyone
+# can afford a monstrous wall-sized display.
+max-line-length = 119


### PR DESCRIPTION
* `examples/roundtrip.py` - Round trip all the files in given directory with a given file extension. Output the round-tripped files to the given output directory
* `examples/rdf-compare.py` - Compare two RDF files or two parallel directory trees of RDF files. Log differences at warning level.
