### PR TITLE
Change import of collections types.

### DIFF
--- a/sbol3/property_base.py
+++ b/sbol3/property_base.py
@@ -1,6 +1,6 @@
 import abc
 import collections
-from collections import MutableSequence, Iterable
+from collections.abc import MutableSequence, Iterable
 from typing import Any, Optional, List, Dict, Union
 
 from sbol3 import ValidationReport


### PR DESCRIPTION
I was getting this warning:

```
Warning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import MutableSequence, Iterable

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```