### PR TITLE
Clean up deprecation warnings

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,6 +30,6 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         python -m pip install .
         python -m pip install 'pycodestyle>=2.6.0'
-    - name: Test with pytest
+    - name: Test with unittest
       run: |
-        python -m unittest discover -s test
+        python -We -m unittest discover -s test

--- a/sbol3/property_base.py
+++ b/sbol3/property_base.py
@@ -127,7 +127,7 @@ class ListProperty(Property, MutableSequence, abc.ABC):
         value = self._storage()[self.property_uri].__getitem__(key)
         if isinstance(value, str):
             return self.to_user(value)
-        elif isinstance(value, collections.Iterable):
+        elif isinstance(value, collections.abc.Iterable):
             return [self.to_user(v) for v in value]
         else:
             # Not a string or an iterable, just convert

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -1,7 +1,7 @@
 import os
 import posixpath
 import unittest
-from collections import Container
+from collections.abc import Container
 
 import sbol3
 

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -1,7 +1,7 @@
 import math
 import posixpath
 import unittest
-from collections import Iterable
+from collections.abc import Iterable
 
 import rdflib
 

--- a/test/test_toplevel.py
+++ b/test/test_toplevel.py
@@ -26,7 +26,11 @@ class MyTestCase(unittest.TestCase):
     def test_default_namespace(self):
         # See https://github.com/SynBioDex/pySBOL3/issues/263
         display_id = 'foo'
-        c = sbol3.Component(display_id, sbol3.SBO_DNA)
+        with self.assertWarns(UserWarning) as cm:
+            c = sbol3.Component(display_id, sbol3.SBO_DNA)
+        # Verify that the generated warning says something about sbol3.set_namespace
+        self.assertIn('set_namespace', str(cm.warning))
+        # Ensure that the component has a namespace. This was bug 263, see link above
         self.assertIsNotNone(c.namespace)
         self.assertTrue(c.identity.endswith(display_id))
         self.assertEqual(c.identity, posixpath.join(c.namespace, display_id))


### PR DESCRIPTION
* Import from `collections` has been deprecated since Python 3.3 and will no longer work in Python 3.10. Stop importing from `collections` and instead use `collections.abc`.
* Modify the GitHub Actions to flag all Python warnings as errors in order to catch future deprecation issues early.

Closes #274 
