### PR TITLE
Pin rdflib and pyshacl dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(name='sbol3',
             'rdflib-jsonld',
             'python-dateutil',
             'pyshacl==0.14',
+            'requests',
       ],
       test_suite='test',
       tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,10 @@ setup(name='sbol3',
       packages=['sbol3'],
       package_data={'sbol3': ['rdf/sbol3-shapes.ttl']},
       install_requires=[
-            'rdflib>=5.0',
+            'rdflib==5',
             'rdflib-jsonld',
             'python-dateutil',
-            'pyshacl',
+            'pyshacl==0.14',
       ],
       test_suite='test',
       tests_require=[


### PR DESCRIPTION
Before working on compatibility with new releases, pin the dependencies so that pySBOL3 users do not break prior to establishing compatibility with the new releases of rdflib and pyshacl.

Fixes #280 