### PR TITLE
Update pyshacl to 0.15

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -423,7 +423,7 @@ class Document:
                                         shacl_graph=shacl_graph,
                                         ont_graph=None,
                                         inference=None,
-                                        abort_on_error=False,
+                                        abort_on_first=False,
                                         meta_shacl=False,
                                         advanced=True,
                                         debug=False)

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,10 @@ setup(name='sbol3',
       packages=['sbol3'],
       package_data={'sbol3': ['rdf/sbol3-shapes.ttl']},
       install_requires=[
-            'rdflib==5',
+            'rdflib>=5,<6',
             'rdflib-jsonld',
             'python-dateutil',
-            'pyshacl==0.14',
-            'requests',
+            'pyshacl>=0.15,<=0.16',
       ],
       test_suite='test',
       tests_require=[


### PR DESCRIPTION
Be better about dependency management by specifying minimum and
maximum versions of pyshacl and rdflib.

Prerequisite of #279 