### PR TITLE
rdflib 6 compatibility

### DIFF
--- a/examples/rdf-compare.py
+++ b/examples/rdf-compare.py
@@ -33,10 +33,10 @@ def init_logging(debug=False):
 def compare_files(file1, file2):
     # Now compare the graphs in RDF
     g1 = rdflib.Graph()
-    g1.load(file1.as_posix(), format=rdflib.util.guess_format(file1.as_posix()))
+    g1.parse(file1.as_posix(), format=rdflib.util.guess_format(file1.as_posix()))
     iso1 = rdflib.compare.to_isomorphic(g1)
     g2 = rdflib.Graph()
-    g2.load(file2.as_posix(), format=rdflib.util.guess_format(file2.as_posix()))
+    g2.parse(file2.as_posix(), format=rdflib.util.guess_format(file2.as_posix()))
     iso2 = rdflib.compare.to_isomorphic(g2)
     rdf_diff = rdflib.compare.graph_diff(iso1, iso2)
     if rdf_diff[1] or rdf_diff[2]:

--- a/sbol3/__init__.py
+++ b/sbol3/__init__.py
@@ -1,5 +1,18 @@
 __version__ = '1.0b6'
 
+# ---------- BEGIN WARNING WORKAROUND ----------
+# Avoid unsightly warnings caused by rdflib 6, and manifested
+# during the import of owlrl either directly or via pyshacl.
+# See https://github.com/RDFLib/OWL-RL/issues/44
+#
+# TODO: Delete this workaround when owlrl handles these warnings
+#
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", category=UserWarning)
+    import owlrl
+# ---------- END WARNING WORKAROUND ----------
+
 from .constants import *
 from .config import set_defaults, get_namespace, set_namespace
 # get_homespace and set_homespace are deprecated and included for backward compatibility

--- a/sbol3/constants.py
+++ b/sbol3/constants.py
@@ -255,7 +255,7 @@ SBO_MODIFIED = SBO_NS + '0000644'
 SBO_TEMPLATE = SBO_NS + '0000645'
 
 # RDF File Formats
-NTRIPLES = 'nt'
+NTRIPLES = 'nt11'
 RDF_XML = 'xml'
 TURTLE = 'ttl'
 JSONLD = 'json-ld'

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -1,7 +1,6 @@
 import collections
 import logging
 import os
-import warnings
 from typing import Dict, Callable, List, Optional, Any, Union
 
 import pyshacl

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -6,10 +6,6 @@ from typing import Dict, Callable, List, Optional, Any, Union
 
 import pyshacl
 import rdflib
-# Get the rdflib-jsonld capability initialized
-# Note: this is for side effect. The parser is not used.
-# The side effect is that the JSON-LD parser is registered in RDFlib.
-from rdflib_jsonld import parser as jsonld_parser
 
 from . import *
 from .object import BUILDER_REGISTER

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -253,7 +253,7 @@ class Document:
         if file_format == SORTED_NTRIPLES:
             file_format = NTRIPLES
         graph = rdflib.Graph()
-        graph.load(location, format=file_format)
+        graph.parse(location, format=file_format)
         return self._parse_graph(graph)
 
     # Formats: 'n3', 'nt', 'turtle', 'xml'

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -236,7 +236,13 @@ class Document:
         self._other_rdf = graph
 
     def _guess_format(self, fpath: str):
-        return rdflib.util.guess_format(fpath)
+        rdf_format = rdflib.util.guess_format(fpath)
+        if rdf_format == 'nt':
+            # Use N-Triples 1.1 format
+            # See https://github.com/RDFLib/rdflib/issues/1376
+            # See https://github.com/RDFLib/rdflib/issues/1377
+            rdf_format = 'nt11'
+        return rdf_format
 
     # Formats: 'n3', 'nt', 'turtle', 'xml'
     def read(self, location: str, file_format: str = None) -> None:
@@ -306,7 +312,7 @@ class Document:
         graph = self.graph()
         if file_format == SORTED_NTRIPLES:
             # have RDFlib give us the ntriples as a string
-            nt_text = graph.serialize(format='nt')
+            nt_text = graph.serialize(format=NTRIPLES)
             # split it into lines
             lines = nt_text.splitlines(keepends=True)
             # sort those lines

--- a/setup.py
+++ b/setup.py
@@ -36,12 +36,11 @@ setup(name='sbol3',
       packages=['sbol3'],
       package_data={'sbol3': ['rdf/sbol3-shapes.ttl']},
       install_requires=[
-            'rdflib>=5,<6',
-            'rdflib-jsonld',
-            'python-dateutil',
-            'pyshacl>=0.15,<=0.16',
+            'rdflib~=6.0',
+            'python-dateutil~=2.8',
+            'pyshacl~=0.15.0',
       ],
       test_suite='test',
       tests_require=[
-            'pycodestyle>=2.6.0'
+            'pycodestyle~=2.7.0'
       ])

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -40,11 +40,11 @@ class TestExamples(unittest.TestCase):
         self.assertTrue(os.path.exists(out_path))
         # Load the output
         actual_graph = rdflib.Graph()
-        actual_graph.load(out_path, format=sbol3.NTRIPLES)
+        actual_graph.parse(out_path, format=sbol3.NTRIPLES)
         actual_iso = rdflib.compare.to_isomorphic(actual_graph)
         # Load the expected output
         expected_graph = rdflib.Graph()
-        expected_graph.load(EXPECTED_CIRCUIT, format=sbol3.NTRIPLES)
+        expected_graph.parse(EXPECTED_CIRCUIT, format=sbol3.NTRIPLES)
         expected_iso = rdflib.compare.to_isomorphic(expected_graph)
         rdf_diff = rdflib.compare.graph_diff(expected_iso, actual_iso)
         if rdf_diff[1] or rdf_diff[2]:

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -140,10 +140,10 @@ class TestRoundTrip(unittest.TestCase):
 
         # Now compare the graphs in RDF
         g1 = rdflib.Graph()
-        g1.load(test_path, format=file_format)
+        g1.parse(test_path, format=file_format)
         iso1 = rdflib.compare.to_isomorphic(g1)
         g2 = rdflib.Graph()
-        g2.load(test2_path, format=file_format)
+        g2.parse(test2_path, format=file_format)
         iso2 = rdflib.compare.to_isomorphic(g2)
         rdf_diff = rdflib.compare.graph_diff(iso1, iso2)
         if rdf_diff[1] or rdf_diff[2]:


### PR DESCRIPTION
* Switch to N-Triples 1.1 format to avoid a confusing encoding warning
* Use `rdflib.Graph.parse` instead of `rdflib.Graph.load` because load is deprecated in rdflib 6
* Handle `bytes` or `str` from `rdflib.Graph.serialize`
  * rdflib 6 returns `str` from `serialize` instead of `bytes` as rdflib 5 did
* Add a temporary workaround for [unsightly user warnings](https://github.com/RDFLib/OWL-RL/issues/44)
* Stop importing jsonld parser because it is no longer necessary in rdflib 6
* Change dependencies to use rdflib 6

Closes #279 