### PR TITLE
Bump pySHACL dependency

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -6,6 +6,11 @@ from typing import Dict, Callable, List, Optional, Any, Union
 import pyshacl
 import rdflib
 
+# We really shouldn't need to do this.
+# See https://github.com/RDFLib/rdflib/issues/1412
+# When this gets fixed we can remove the explicit import of rdflib.plugins.parsers.jsonld
+import rdflib.plugins.parsers.jsonld
+
 from . import *
 from .object import BUILDER_REGISTER
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name='sbol3',
       install_requires=[
             'rdflib~=6.0',
             'python-dateutil~=2.8',
-            'pyshacl~=0.15.0',
+            'pyshacl~=0.17.0',
       ],
       test_suite='test',
       tests_require=[


### PR DESCRIPTION
Update to new pySHACL dependency to work around an issue with one of
its dependencies. Also work around a bug in RDFLib 6 that requires us
to import the json-ld parser explicitly in order for
rdflib.util.guess_format to work.