### PR TITLE
Require rdflib 6.0.1 or higher

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -6,11 +6,6 @@ from typing import Dict, Callable, List, Optional, Any, Union
 import pyshacl
 import rdflib
 
-# We really shouldn't need to do this.
-# See https://github.com/RDFLib/rdflib/issues/1412
-# When this gets fixed we can remove the explicit import of rdflib.plugins.parsers.jsonld
-import rdflib.plugins.parsers.jsonld
-
 from . import *
 from .object import BUILDER_REGISTER
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ setup(name='sbol3',
       packages=['sbol3'],
       package_data={'sbol3': ['rdf/sbol3-shapes.ttl']},
       install_requires=[
-            'rdflib~=6.0',
+            # Require at least rdflib 6.0.1, and allow newer versions
+            # of rdflib 6.x
+            'rdflib>=6.0.1,==6.*',
             'python-dateutil~=2.8',
             'pyshacl~=0.17.0',
       ],


### PR DESCRIPTION
Allow any rdflib 6.* version, and require a minimum version of 6.0.1 to
get the json-ld bug fix.

Fixes #314 