### PR TITLE
Propagate the new document pointer after copy

### DIFF
--- a/sbol3/toplevel.py
+++ b/sbol3/toplevel.py
@@ -111,6 +111,14 @@ class TopLevel(Identified):
         obj.traverse(make_update_references_traverser(identity_map))
         return obj
 
+    def copy(self, target_doc=None, target_namespace=None):
+        new_obj = super().copy(target_doc=target_doc, target_namespace=target_namespace)
+        # Need to set `document` on all children recursively. That's what happens when
+        # you assign to the `document` property of an Identified
+        new_obj.document = target_doc
+        # Comply with the contract of super.copy()
+        return new_obj
+
 
 def make_erase_identity_traverser(identity_map: Dict[str, Identified])\
         -> Callable[[Identified], None]:


### PR DESCRIPTION
Fix a bug where child objects did not have a pointer to their document.
This caused `lookup` to fail. Propagate the document pointer in an
after method on TopLevel.

Closes #176 (again)
