### PR TITLE
Add Python 3.10 to GitHub Actions build

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,11 +38,9 @@ jobs:
         python -m pip install .
         python -m pip install 'pycodestyle>=2.6.0'
     - name: Test with unittest
+      # pyshacl has a 3.10 deprecation warning in distutils
+      # disable warnings until we tune to ignore distutils deprecation warning
       run: |
         WARNINGS="-We"
-        if [ "${{ matrix.python-version }}" == "3.10 ]; then
-	    # pyshacl has a 3.10 deprecation warning in distutils
-	    # disable warnings until we tune to ignore distutils deprecation warning
-	    WARNINGS=""
-	fi
+        if [ "${{ matrix.python-version }}" == "3.10 ]; then WARNINGS="" fi
         python $WARNINGS -m unittest discover -s test

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,5 +42,5 @@ jobs:
       # disable warnings until we tune to ignore distutils deprecation warning
       run: |
         WARNINGS="-We"
-        if [ "${{ matrix.python-version }}" == "3.10" ]; then WARNINGS=""; fi
+        if [ "${{ matrix.python-version }}" == "3.10" ]; then echo "Disabling warnings"; WARNINGS=""; fi
         python $WARNINGS -m unittest discover -s test

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # Default builds are on Ubuntu
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, pypy-3.7]
+        python-version: [3.7, 3.8, 3.9, 3.10, pypy-3.7]
         include:
           # Also test on macOS and Windows using latest Python 3
           - os: macos-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,13 +16,13 @@ jobs:
       matrix:
         # Default builds are on Ubuntu
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10, pypy-3.7]
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7']
         include:
           # Also test on macOS and Windows using latest Python 3
           - os: macos-latest
-            python-version: 3.x
+            python-version: '3.x'
           - os: windows-latest
-            python-version: 3.x
+            python-version: '3.x'
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,4 +39,10 @@ jobs:
         python -m pip install 'pycodestyle>=2.6.0'
     - name: Test with unittest
       run: |
-        python -We -m unittest discover -s test
+        WARNINGS="-We"
+        if [ "${{ matrix.python-version }}" == "3.10 ]; then
+	    # pyshacl has a 3.10 deprecation warning in distutils
+	    # disable warnings until we tune to ignore distutils deprecation warning
+	    WARNINGS=""
+	fi
+        python $WARNINGS -m unittest discover -s test

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,5 +42,5 @@ jobs:
       # disable warnings until we tune to ignore distutils deprecation warning
       run: |
         WARNINGS="-We"
-        if [ "${{ matrix.python-version }}" == "3.10 ]; then WARNINGS="" fi
+        if [ "${{ matrix.python-version }}" == "3.10" ]; then WARNINGS="" fi
         python $WARNINGS -m unittest discover -s test

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,5 +42,5 @@ jobs:
       # disable warnings until we tune to ignore distutils deprecation warning
       run: |
         WARNINGS="-We"
-        if [ "${{ matrix.python-version }}" == "3.10" ]; then WARNINGS="" fi
+        if [ "${{ matrix.python-version }}" == "3.10" ]; then WARNINGS=""; fi
         python $WARNINGS -m unittest discover -s test


### PR DESCRIPTION
Python 3.10 was released recently. Add it to the automatic builds.

There is a deprecation warning in pyshacl because of its use of distutils which will be deprecated in python 3.12. The warnings check is disabled in Python 3.10 to avoid breakage. It would be nice to figure out how to disable the deprecation warnings in distutils instead of dropping the warnings check altogether. I don't have the patience to figure that out right now.