### PR TITLE
SBOL 3.0.1:  ComponentReferenct.hasFeature -> ComponentReference.refersTo

### DIFF
--- a/sbol3/compref.py
+++ b/sbol3/compref.py
@@ -12,7 +12,7 @@ class ComponentReference(Feature):
     """
 
     def __init__(self, in_child_of: Union[SubComponent, str],
-                 feature: Union[Feature, str],
+                 refers_to: Union[Feature, str],
                  *, roles: List[str] = None, orientation: str = None,
                  name: str = None, description: str = None,
                  derived_from: List[str] = None,
@@ -26,13 +26,13 @@ class ComponentReference(Feature):
                          generated_by=generated_by, measures=measures)
         self.in_child_of = ReferencedObject(self, SBOL_IN_CHILD_OF, 1, 1,
                                             initial_value=in_child_of)
-        self.feature = ReferencedObject(self, SBOL_FEATURES, 1, 1,
-                                        initial_value=feature)
+        self.refers_to = ReferencedObject(self, SBOL_REFERS_TO, 1, 1,
+                                          initial_value=refers_to)
 
     def validate(self, report: ValidationReport = None) -> ValidationReport:
         report = super().validate(report)
-        # Must have 1 feature
-        if self.feature is None:
+        # Must have 1 refersTo
+        if self.refers_to is None:
             message = 'ComponentReference must have a feature'
             report.addError(self.identity, None, message)
         # Must have 1 in_child_of

--- a/sbol3/constants.py
+++ b/sbol3/constants.py
@@ -90,6 +90,7 @@ SBOL_PARTICIPANT = SBOL3_NS + 'participant'
 SBOL_PARTCIPATION = SBOL3_NS + 'Participation'
 SBOL_PARTICIPATIONS = SBOL3_NS + 'hasParticipation'
 SBOL_RANGE = SBOL3_NS + 'Range'
+SBOL_REFERS_TO = SBOL3_NS + 'refersTo'
 SBOL_RESTRICTION = SBOL3_NS + 'restriction'
 SBOL_ROLE = SBOL3_NS + 'role'
 SBOL_SEQUENCE = SBOL3_NS + 'Sequence'
@@ -181,6 +182,10 @@ SO_ENGINEERED_REGION = SO_NS + '0000804'
 SO_MRNA = SO_NS + "0000234"
 CHEBI_EFFECTOR = CHEBI_NS + '35224'
 SO_TRANSCRIPTION_FACTOR = SO_NS + "0003700"
+
+# Feature Orientations
+SO_FORWARD = SO_NS + '0001030'
+SO_REVERSE = SO_NS + '0001031'
 
 # Component types
 # See the SBOL 3 spec, Section 6.4, Table 2

--- a/sbol3/feature.py
+++ b/sbol3/feature.py
@@ -26,7 +26,8 @@ class Feature(Identified, abc.ABC):
         report = super().validate(report)
         # If there is an orientation, it must be in the valid set
         if self.orientation is not None:
-            valid_orientations = [SBOL_INLINE, SBOL_REVERSE_COMPLEMENT]
+            valid_orientations = [SO_FORWARD, SO_REVERSE,
+                                  SBOL_INLINE, SBOL_REVERSE_COMPLEMENT]
             if self.orientation not in valid_orientations:
                 message = f'{self.orientation} is not a valid orientation'
                 report.addError(self.identity, None, message)

--- a/sbol3/rdf/sbol3-shapes.ttl
+++ b/sbol3/rdf/sbol3-shapes.ttl
@@ -10,11 +10,11 @@
         owl:Class,
         sh:NodeShape ;
     rdfs:label "Attachment"^^xsd:string ;
-    rdfs:subClassOf [ a rdfs:Resource,
+    rdfs:subClassOf _:Nbbe2110b34714c958d17607763905bd6,
+        [ a rdfs:Resource,
                 owl:Restriction ;
             owl:onProperty <http://sbols.org/v3#source> ;
             owl:someValuesFrom owl:Thing ],
-        _:Nb31b8ad0714d498680441d7e8b1a63cc,
         <http://sbols.org/v3#Identified>,
         <http://sbols.org/v3#TopLevel>,
         owl:Thing ;
@@ -30,7 +30,7 @@
         owl:Class,
         sh:NodeShape ;
     rdfs:label "Collection"^^xsd:string ;
-    rdfs:subClassOf _:Nb31b8ad0714d498680441d7e8b1a63cc,
+    rdfs:subClassOf _:Nbbe2110b34714c958d17607763905bd6,
         <http://sbols.org/v3#Identified>,
         <http://sbols.org/v3#TopLevel>,
         owl:Thing ;
@@ -46,7 +46,7 @@
                 owl:Restriction ;
             owl:onProperty <http://sbols.org/v3#template> ;
             owl:someValuesFrom <http://sbols.org/v3#Component> ],
-        _:Nb31b8ad0714d498680441d7e8b1a63cc,
+        _:Nbbe2110b34714c958d17607763905bd6,
         <http://sbols.org/v3#Identified>,
         <http://sbols.org/v3#TopLevel>,
         owl:Thing ;
@@ -64,7 +64,7 @@
                 owl:Restriction ;
             owl:onProperty <http://sbols.org/v3#type> ;
             owl:someValuesFrom owl:Thing ],
-        _:Nb31b8ad0714d498680441d7e8b1a63cc,
+        _:Nbbe2110b34714c958d17607763905bd6,
         <http://sbols.org/v3#Identified>,
         <http://sbols.org/v3#TopLevel>,
         owl:Thing ;
@@ -85,22 +85,17 @@
     rdfs:label "ComponentReference"^^xsd:string ;
     rdfs:subClassOf [ a rdfs:Resource,
                 owl:Restriction ;
-            owl:onProperty <http://sbols.org/v3#hasFeature> ;
-            owl:someValuesFrom <http://sbols.org/v3#Feature> ],
-        [ a rdfs:Resource,
-                owl:Restriction ;
             owl:onProperty <http://sbols.org/v3#inChildOf> ;
             owl:someValuesFrom <http://sbols.org/v3#Component> ],
         [ a rdfs:Resource,
                 owl:Restriction ;
-            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-            owl:onClass <http://sbols.org/v3#Feature> ;
-            owl:onProperty <http://sbols.org/v3#hasFeature> ],
+            owl:onProperty <http://sbols.org/v3#refersTo> ;
+            owl:someValuesFrom <http://sbols.org/v3#Feature> ],
         <http://sbols.org/v3#Feature>,
         <http://sbols.org/v3#Identified>,
         owl:Thing ;
-    sh:property <http://sbols.org/v3#ComponentReference-hasFeature>,
-        <http://sbols.org/v3#ComponentReference-inChildOf> .
+    sh:property <http://sbols.org/v3#ComponentReference-inChildOf>,
+        <http://sbols.org/v3#ComponentReference-refersTo> .
 
 <http://sbols.org/v3#Constraint> a rdfs:Class,
         rdfs:Resource,
@@ -109,15 +104,15 @@
     rdfs:label "Constraint"^^xsd:string ;
     rdfs:subClassOf [ a rdfs:Resource,
                 owl:Restriction ;
-            owl:onProperty <http://sbols.org/v3#object> ;
-            owl:someValuesFrom <http://sbols.org/v3#Feature> ],
-        [ a rdfs:Resource,
-                owl:Restriction ;
             owl:onProperty <http://sbols.org/v3#restriction> ;
             owl:someValuesFrom owl:Thing ],
         [ a rdfs:Resource,
                 owl:Restriction ;
             owl:onProperty <http://sbols.org/v3#subject> ;
+            owl:someValuesFrom <http://sbols.org/v3#Feature> ],
+        [ a rdfs:Resource,
+                owl:Restriction ;
+            owl:onProperty <http://sbols.org/v3#object> ;
             owl:someValuesFrom <http://sbols.org/v3#Feature> ],
         <http://sbols.org/v3#Identified>,
         owl:Thing ;
@@ -130,9 +125,7 @@
         owl:Class,
         sh:NodeShape ;
     rdfs:label "Cut"^^xsd:string ;
-    rdfs:subClassOf _:N9c29433e368f4ecaa0a2c6bcfced763b,
-        _:Naba636fce7cd4ffba64ee6c569f26409,
-        [ a rdfs:Resource,
+    rdfs:subClassOf [ a rdfs:Resource,
                 owl:Restriction ;
             owl:onProperty <http://sbols.org/v3#at> ;
             owl:someValuesFrom [ a rdfs:Datatype,
@@ -143,6 +136,8 @@
                             rdf:first [ a rdfs:Resource ;
                                     xsd:minInclusive 0 ] ;
                             rdf:rest () ] ] ],
+        _:Nd1d56f7c8c8f48c3b688dc0d6efe4dc7,
+        _:Nf6ec36b498544b77a87b4a008105fb71,
         <http://sbols.org/v3#Identified>,
         <http://sbols.org/v3#Location>,
         owl:Thing ;
@@ -154,8 +149,8 @@
         owl:Class,
         sh:NodeShape ;
     rdfs:label "EntireSequence"^^xsd:string ;
-    rdfs:subClassOf _:N9c29433e368f4ecaa0a2c6bcfced763b,
-        _:Naba636fce7cd4ffba64ee6c569f26409,
+    rdfs:subClassOf _:Nd1d56f7c8c8f48c3b688dc0d6efe4dc7,
+        _:Nf6ec36b498544b77a87b4a008105fb71,
         <http://sbols.org/v3#Identified>,
         <http://sbols.org/v3#Location>,
         owl:Thing ;
@@ -166,7 +161,7 @@
         owl:Class,
         sh:NodeShape ;
     rdfs:label "Experiment"^^xsd:string ;
-    rdfs:subClassOf _:Nb31b8ad0714d498680441d7e8b1a63cc,
+    rdfs:subClassOf _:Nbbe2110b34714c958d17607763905bd6,
         <http://sbols.org/v3#Collection>,
         <http://sbols.org/v3#Identified>,
         <http://sbols.org/v3#TopLevel>,
@@ -178,7 +173,7 @@
         owl:Class,
         sh:NodeShape ;
     rdfs:label "ExperimentalData"^^xsd:string ;
-    rdfs:subClassOf _:Nb31b8ad0714d498680441d7e8b1a63cc,
+    rdfs:subClassOf _:Nbbe2110b34714c958d17607763905bd6,
         <http://sbols.org/v3#Identified>,
         <http://sbols.org/v3#TopLevel>,
         owl:Thing ;
@@ -229,7 +224,7 @@
         owl:Class,
         sh:NodeShape ;
     rdfs:label "Implementation"^^xsd:string ;
-    rdfs:subClassOf _:Nb31b8ad0714d498680441d7e8b1a63cc,
+    rdfs:subClassOf _:Nbbe2110b34714c958d17607763905bd6,
         <http://sbols.org/v3#Identified>,
         <http://sbols.org/v3#TopLevel>,
         owl:Thing ;
@@ -281,8 +276,8 @@
         owl:Class,
         sh:NodeShape ;
     rdfs:label "Location"^^xsd:string ;
-    rdfs:subClassOf _:N9c29433e368f4ecaa0a2c6bcfced763b,
-        _:Naba636fce7cd4ffba64ee6c569f26409,
+    rdfs:subClassOf _:Nd1d56f7c8c8f48c3b688dc0d6efe4dc7,
+        _:Nf6ec36b498544b77a87b4a008105fb71,
         <http://sbols.org/v3#Identified>,
         owl:Thing ;
     sh:property <http://sbols.org/v3#Location-hasSequence>,
@@ -296,17 +291,17 @@
     rdfs:label "Model"^^xsd:string ;
     rdfs:subClassOf [ a rdfs:Resource,
                 owl:Restriction ;
-            owl:onProperty <http://sbols.org/v3#language> ;
+            owl:onProperty <http://sbols.org/v3#source> ;
             owl:someValuesFrom owl:Thing ],
+        _:Nbbe2110b34714c958d17607763905bd6,
         [ a rdfs:Resource,
                 owl:Restriction ;
             owl:onProperty <http://sbols.org/v3#framework> ;
             owl:someValuesFrom owl:Thing ],
         [ a rdfs:Resource,
                 owl:Restriction ;
-            owl:onProperty <http://sbols.org/v3#source> ;
+            owl:onProperty <http://sbols.org/v3#language> ;
             owl:someValuesFrom owl:Thing ],
-        _:Nb31b8ad0714d498680441d7e8b1a63cc,
         <http://sbols.org/v3#Identified>,
         <http://sbols.org/v3#TopLevel>,
         owl:Thing ;
@@ -335,9 +330,7 @@
         owl:Class,
         sh:NodeShape ;
     rdfs:label "Range"^^xsd:string ;
-    rdfs:subClassOf _:N9c29433e368f4ecaa0a2c6bcfced763b,
-        _:Naba636fce7cd4ffba64ee6c569f26409,
-        [ a rdfs:Resource,
+    rdfs:subClassOf [ a rdfs:Resource,
                 owl:Restriction ;
             owl:onProperty <http://sbols.org/v3#start> ;
             owl:someValuesFrom [ a rdfs:Datatype,
@@ -359,6 +352,8 @@
                             rdf:first [ a rdfs:Resource ;
                                     xsd:minInclusive 1 ] ;
                             rdf:rest () ] ] ],
+        _:Nd1d56f7c8c8f48c3b688dc0d6efe4dc7,
+        _:Nf6ec36b498544b77a87b4a008105fb71,
         <http://sbols.org/v3#Identified>,
         <http://sbols.org/v3#Location>,
         owl:Thing ;
@@ -371,7 +366,7 @@
         owl:Class,
         sh:NodeShape ;
     rdfs:label "Sequence"^^xsd:string ;
-    rdfs:subClassOf _:Nb31b8ad0714d498680441d7e8b1a63cc,
+    rdfs:subClassOf _:Nbbe2110b34714c958d17607763905bd6,
         <http://sbols.org/v3#Identified>,
         <http://sbols.org/v3#TopLevel>,
         owl:Thing ;
@@ -415,7 +410,7 @@
         owl:Class,
         sh:NodeShape ;
     rdfs:label "TopLevel"^^xsd:string ;
-    rdfs:subClassOf _:Nb31b8ad0714d498680441d7e8b1a63cc,
+    rdfs:subClassOf _:Nbbe2110b34714c958d17607763905bd6,
         <http://sbols.org/v3#Identified>,
         owl:Thing ;
     sh:property <http://sbols.org/v3#TopLevel-hasAttachment>,
@@ -497,6 +492,10 @@
 <http://sbols.org/v3#hasConstraint-shape> a sh:NodeShape ;
     sh:class <http://sbols.org/v3#Component> ;
     sh:targetSubjectsOf <http://sbols.org/v3#hasConstraint> .
+
+<http://sbols.org/v3#hasFeature-shape> a sh:NodeShape ;
+    sh:class <http://sbols.org/v3#Component> ;
+    sh:targetSubjectsOf <http://sbols.org/v3#hasFeature> .
 
 <http://sbols.org/v3#hasInteraction-shape> a sh:NodeShape ;
     sh:class <http://sbols.org/v3#Component> ;
@@ -581,6 +580,10 @@
 <http://sbols.org/v3#participant-shape> a sh:NodeShape ;
     sh:class <http://sbols.org/v3#Participation> ;
     sh:targetSubjectsOf <http://sbols.org/v3#participant> .
+
+<http://sbols.org/v3#refersTo-shape> a sh:NodeShape ;
+    sh:class <http://sbols.org/v3#ComponentReference> ;
+    sh:targetSubjectsOf <http://sbols.org/v3#refersTo> .
 
 <http://sbols.org/v3#restriction-shape> a sh:NodeShape ;
     sh:class <http://sbols.org/v3#Constraint> ;
@@ -733,18 +736,18 @@
     sh:minCount 1 ;
     sh:path <http://sbols.org/v3#type> .
 
-<http://sbols.org/v3#ComponentReference-hasFeature> a sh:PropertyShape ;
-    sh:class <http://sbols.org/v3#Feature> ;
-    sh:maxCount 1 ;
-    sh:minCount 1 ;
-    sh:path <http://sbols.org/v3#hasFeature> .
-
 <http://sbols.org/v3#ComponentReference-inChildOf> a sh:PropertyShape ;
     dash:hasValueWithClass <http://sbols.org/v3#Component> ;
     sh:class <http://sbols.org/v3#SubComponent> ;
     sh:maxCount 1 ;
     sh:minCount 1 ;
     sh:path <http://sbols.org/v3#inChildOf> .
+
+<http://sbols.org/v3#ComponentReference-refersTo> a sh:PropertyShape ;
+    sh:class <http://sbols.org/v3#Feature> ;
+    sh:maxCount 1 ;
+    sh:minCount 1 ;
+    sh:path <http://sbols.org/v3#refersTo> .
 
 <http://sbols.org/v3#Constraint-object> a sh:PropertyShape ;
     sh:class <http://sbols.org/v3#Feature> ;
@@ -1045,6 +1048,8 @@ xsd:minInclusive a rdf:Property ;
 
 owl:Ontology a rdfs:Resource .
 
+owl:TransitiveProperty a rdfs:Resource .
+
 owl:equivalentClass a rdf:Property ;
     rdfs:subPropertyOf owl:equivalentClass .
 
@@ -1068,6 +1073,8 @@ owl:unionOf a rdf:Property ;
 
 owl:withRestrictions a rdf:Property ;
     rdfs:subPropertyOf owl:withRestrictions .
+
+"1"^^xsd:nonNegativeInteger a rdfs:Resource .
 
 "Attachment"^^xsd:string a rdfs:Resource .
 
@@ -1131,9 +1138,13 @@ owl:withRestrictions a rdf:Property ;
 
 "cardinality"^^xsd:string a rdfs:Resource .
 
+"comprises"^^xsd:string a rdfs:Resource .
+
 "definition"^^xsd:string a rdfs:Resource .
 
 "description"^^xsd:string a rdfs:Resource .
+
+"directlyComprises"^^xsd:string a rdfs:Resource .
 
 "displayId"^^xsd:string a rdfs:Resource .
 
@@ -1171,6 +1182,8 @@ owl:withRestrictions a rdf:Property ;
 
 "hasSequence"^^xsd:string a rdfs:Resource .
 
+"hasVariableFeature"^^xsd:string a rdfs:Resource .
+
 "hash"^^xsd:string a rdfs:Resource .
 
 "hashAlgorithm"^^xsd:string a rdfs:Resource .
@@ -1202,6 +1215,10 @@ owl:withRestrictions a rdf:Property ;
 "orientation"^^xsd:string a rdfs:Resource .
 
 "output"^^xsd:string a rdfs:Resource .
+
+"participant"^^xsd:string a rdfs:Resource .
+
+"refersTo"^^xsd:string a rdfs:Resource .
 
 "restriction"^^xsd:string a rdfs:Resource .
 
@@ -1323,26 +1340,42 @@ owl:withRestrictions a rdf:Property ;
         owl:ObjectProperty ;
     rdfs:label "hasConstraint"^^xsd:string ;
     rdfs:domain <http://sbols.org/v3#Component> ;
-    rdfs:range <http://sbols.org/v3#Constraint> .
+    rdfs:range <http://sbols.org/v3#Constraint> ;
+    rdfs:subPropertyOf <http://sbols.org/v3#comprises>,
+        <http://sbols.org/v3#directlyComprises> .
+
+<http://sbols.org/v3#hasFeature> a rdfs:Resource,
+        owl:ObjectProperty ;
+    rdfs:label "hasFeature"^^xsd:string ;
+    rdfs:domain <http://sbols.org/v3#Component> ;
+    rdfs:range <http://sbols.org/v3#Feature> ;
+    rdfs:subPropertyOf <http://sbols.org/v3#comprises>,
+        <http://sbols.org/v3#directlyComprises> .
 
 <http://sbols.org/v3#hasInteraction> a rdfs:Resource,
         owl:ObjectProperty ;
     rdfs:label "hasInteraction"^^xsd:string ;
     rdfs:domain <http://sbols.org/v3#Component> ;
-    rdfs:range <http://sbols.org/v3#Interaction> .
+    rdfs:range <http://sbols.org/v3#Interaction> ;
+    rdfs:subPropertyOf <http://sbols.org/v3#comprises>,
+        <http://sbols.org/v3#directlyComprises> .
 
 <http://sbols.org/v3#hasInterface> a rdfs:Resource,
         owl:FunctionalProperty,
         owl:ObjectProperty ;
     rdfs:label "hasInterface"^^xsd:string ;
     rdfs:domain <http://sbols.org/v3#Component> ;
-    rdfs:range <http://sbols.org/v3#Interface> .
+    rdfs:range <http://sbols.org/v3#Interface> ;
+    rdfs:subPropertyOf <http://sbols.org/v3#comprises>,
+        <http://sbols.org/v3#directlyComprises> .
 
 <http://sbols.org/v3#hasMeasure> a rdfs:Resource,
-        owl:DatatypeProperty ;
+        owl:ObjectProperty ;
     rdfs:label "hasMeasure"^^xsd:string ;
     rdfs:domain <http://sbols.org/v3#Identified> ;
-    rdfs:range <http://www.ontology-of-units-of-measure.org/resource/om-2/Measure> .
+    rdfs:range <http://www.ontology-of-units-of-measure.org/resource/om-2/Measure> ;
+    rdfs:subPropertyOf <http://sbols.org/v3#comprises>,
+        <http://sbols.org/v3#directlyComprises> .
 
 <http://sbols.org/v3#hasModel> a rdfs:Resource,
         owl:ObjectProperty ;
@@ -1354,13 +1387,17 @@ owl:withRestrictions a rdf:Property ;
         owl:ObjectProperty ;
     rdfs:label "hasParticipation"^^xsd:string ;
     rdfs:domain <http://sbols.org/v3#Interaction> ;
-    rdfs:range <http://sbols.org/v3#Participation> .
+    rdfs:range <http://sbols.org/v3#Participation> ;
+    rdfs:subPropertyOf <http://sbols.org/v3#comprises>,
+        <http://sbols.org/v3#directlyComprises> .
 
 <http://sbols.org/v3#hasVariableFeature> a rdfs:Resource,
         owl:ObjectProperty ;
-    rdfs:label "participant"^^xsd:string ;
+    rdfs:label "hasVariableFeature"^^xsd:string ;
     rdfs:domain <http://sbols.org/v3#CombinatorialDerivation> ;
-    rdfs:range <http://sbols.org/v3#VariableFeature> .
+    rdfs:range <http://sbols.org/v3#VariableFeature> ;
+    rdfs:subPropertyOf <http://sbols.org/v3#comprises>,
+        <http://sbols.org/v3#directlyComprises> .
 
 <http://sbols.org/v3#hash> a rdfs:Resource,
         owl:DatatypeProperty,
@@ -1513,11 +1550,13 @@ owl:withRestrictions a rdf:Property ;
         owl:ObjectProperty ;
     rdfs:label "sourceLocation"^^xsd:string ;
     rdfs:domain <http://sbols.org/v3#SubComponent> ;
-    rdfs:range <http://sbols.org/v3#Location> .
+    rdfs:range <http://sbols.org/v3#Location> ;
+    rdfs:subPropertyOf <http://sbols.org/v3#comprises>,
+        <http://sbols.org/v3#directlyComprises> .
 
 <http://sbols.org/v3#strategy> a rdfs:Resource,
-        owl:Class,
-        owl:FunctionalProperty ;
+        owl:FunctionalProperty,
+        owl:ObjectProperty ;
     rdfs:label "strategy"^^xsd:string ;
     rdfs:domain <http://sbols.org/v3#CombinatorialDerivation> ;
     rdfs:range [ a rdfs:Resource,
@@ -1566,10 +1605,6 @@ owl:withRestrictions a rdf:Property ;
         <http://sbols.org/v3#SBOLTerm>,
         owl:Thing .
 
-"1"^^xsd:nonNegativeInteger a rdfs:Resource .
-
-"participant"^^xsd:string a rdfs:Resource .
-
 "start"^^xsd:string a rdfs:Resource .
 
 <http://sbols.org/v3#at> a rdfs:Resource,
@@ -1587,8 +1622,8 @@ owl:withRestrictions a rdf:Property ;
                     rdf:rest () ] ] .
 
 <http://sbols.org/v3#cardinality> a rdfs:Resource,
-        owl:Class,
-        owl:FunctionalProperty ;
+        owl:FunctionalProperty,
+        owl:ObjectProperty ;
     rdfs:label "cardinality"^^xsd:string ;
     rdfs:domain <http://sbols.org/v3#VariableFeature> ;
     rdfs:range [ a rdfs:Resource,
@@ -1656,6 +1691,13 @@ owl:withRestrictions a rdf:Property ;
     rdfs:domain <http://sbols.org/v3#Constraint> ;
     rdfs:range <http://sbols.org/v3#Feature> .
 
+<http://sbols.org/v3#refersTo> a rdfs:Resource,
+        owl:FunctionalProperty,
+        owl:ObjectProperty ;
+    rdfs:label "refersTo"^^xsd:string ;
+    rdfs:domain <http://sbols.org/v3#ComponentReference> ;
+    rdfs:range <http://sbols.org/v3#Feature> .
+
 <http://sbols.org/v3#restriction> a rdfs:Resource,
         owl:FunctionalProperty,
         owl:ObjectProperty ;
@@ -1699,18 +1741,6 @@ owl:withRestrictions a rdf:Property ;
 
 0 a rdfs:Resource .
 
-<http://sbols.org/v3#hasFeature> a rdfs:Resource,
-        owl:ObjectProperty ;
-    rdfs:label "hasFeature"^^xsd:string ;
-    rdfs:domain [ a rdfs:Resource,
-                owl:Class ;
-            owl:unionOf [ a rdfs:Resource ;
-                    rdf:first <http://sbols.org/v3#Component> ;
-                    rdf:rest [ a rdfs:Resource ;
-                            rdf:first <http://sbols.org/v3#ComponentReference> ;
-                            rdf:rest () ] ] ] ;
-    rdfs:range <http://sbols.org/v3#Feature> .
-
 <http://sbols.org/v3#hasLocation> a rdfs:Resource,
         owl:ObjectProperty ;
     rdfs:label "hasLocation"^^xsd:string ;
@@ -1723,7 +1753,9 @@ owl:withRestrictions a rdf:Property ;
                             rdf:rest [ a rdfs:Resource ;
                                     rdf:first <http://sbols.org/v3#SequenceFeature> ;
                                     rdf:rest () ] ] ] ] ;
-    rdfs:range <http://sbols.org/v3#Location> .
+    rdfs:range <http://sbols.org/v3#Location> ;
+    rdfs:subPropertyOf <http://sbols.org/v3#comprises>,
+        <http://sbols.org/v3#directlyComprises> .
 
 <http://sbols.org/v3#role> a rdfs:Resource,
         owl:ObjectProperty ;
@@ -1800,9 +1832,21 @@ rdfs:Datatype a rdfs:Resource .
 
 xsd:integer a rdfs:Resource .
 
+<http://sbols.org/v3#directlyComprises> a rdfs:Resource,
+        owl:ObjectProperty ;
+    rdfs:label "directlyComprises"^^xsd:string ;
+    rdfs:subPropertyOf <http://sbols.org/v3#comprises> .
+
+<http://sbols.org/v3#comprises> a rdfs:Resource,
+        owl:ObjectProperty,
+        owl:TransitiveProperty ;
+    rdfs:label "comprises"^^xsd:string .
+
 <http://sbols.org/v3#SBOLTerm> a rdfs:Resource,
         owl:Class ;
     rdfs:subClassOf owl:Thing .
+
+owl:DatatypeProperty a rdfs:Resource .
 
 <http://sbols.org/v3#hasNamespace> a rdfs:Resource,
         owl:FunctionalProperty,
@@ -1811,8 +1855,6 @@ xsd:integer a rdfs:Resource .
     rdfs:domain <http://sbols.org/v3#TopLevel> .
 
 xsd:string a rdfs:Resource .
-
-owl:DatatypeProperty a rdfs:Resource .
 
 () a rdfs:Resource .
 
@@ -1828,18 +1870,18 @@ owl:Thing a rdfs:Resource .
 
 1 a rdfs:Resource .
 
-_:N9c29433e368f4ecaa0a2c6bcfced763b a rdfs:Resource,
+_:Nd1d56f7c8c8f48c3b688dc0d6efe4dc7 a rdfs:Resource,
         owl:Restriction ;
     owl:onProperty <http://sbols.org/v3#hasSequence> ;
     owl:someValuesFrom <http://sbols.org/v3#Sequence> .
 
-_:Naba636fce7cd4ffba64ee6c569f26409 a rdfs:Resource,
+_:Nf6ec36b498544b77a87b4a008105fb71 a rdfs:Resource,
         owl:Restriction ;
     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
     owl:onClass <http://sbols.org/v3#Sequence> ;
     owl:onProperty <http://sbols.org/v3#hasSequence> .
 
-_:Nb31b8ad0714d498680441d7e8b1a63cc a rdfs:Resource,
+_:Nbbe2110b34714c958d17607763905bd6 a rdfs:Resource,
         owl:Restriction ;
     owl:onProperty <http://sbols.org/v3#hasNamespace> ;
     owl:someValuesFrom owl:Thing .

--- a/test/test_combderiv.py
+++ b/test/test_combderiv.py
@@ -25,7 +25,7 @@ class TestCombinatorialDerivation(unittest.TestCase):
         # Test with invalid strategy
         comp1 = sbol3.Component('comp1', sbol3.SBO_DNA)
         cd1 = sbol3.CombinatorialDerivation('cd1', comp1)
-        cd1.strategy = sbol3.SBOL_INLINE
+        cd1.strategy = sbol3.SO_FORWARD
         report = cd1.validate()
         self.assertIsNotNone(report)
         self.assertEqual(1, len(report.errors))

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -159,7 +159,7 @@ class TestComponent(unittest.TestCase):
             self.assertIsInstance(s_clone, sbol3.ComponentReference)
             self.assertTrue(s_clone.identity.startswith(toggle_clone.identity))
             self.assertNotEqual(s.identity, s_clone.identity)
-            self.assertEqual(s.feature, s_clone.feature)
+            self.assertEqual(s.refers_to, s_clone.refers_to)
             o = c.object.lookup()
             self.assertIsInstance(o, sbol3.ComponentReference)
             self.assertTrue(o.identity.startswith(toggle.identity))
@@ -167,7 +167,7 @@ class TestComponent(unittest.TestCase):
             self.assertIsInstance(o_clone, sbol3.ComponentReference)
             self.assertTrue(o_clone.identity.startswith(toggle_clone.identity))
             self.assertNotEqual(o.identity, o_clone.identity)
-            self.assertEqual(o.feature, o_clone.feature)
+            self.assertEqual(o.refers_to, o_clone.refers_to)
 
 
 if __name__ == '__main__':

--- a/test/test_compref.py
+++ b/test/test_compref.py
@@ -21,7 +21,7 @@ class TestComponentReference(unittest.TestCase):
         comp_ref = sbol3.ComponentReference(in_child_of, feature)
         self.assertIsNotNone(comp_ref)
         self.assertEqual(in_child_of, comp_ref.in_child_of)
-        self.assertEqual(feature, comp_ref.feature)
+        self.assertEqual(feature, comp_ref.refers_to)
 
     def test_read_from_file(self):
         test_file = os.path.join(SBOL3_LOCATION, 'toggle_switch',
@@ -35,7 +35,7 @@ class TestComponentReference(unittest.TestCase):
         in_child_of = 'https://sbolstandard.org/examples/toggle_switch/SubComponent1'
         self.assertEqual(in_child_of, comp_ref.in_child_of)
         feature = 'https://sbolstandard.org/examples/LacI_producer/SubComponent7'
-        self.assertEqual(feature, comp_ref.feature)
+        self.assertEqual(feature, comp_ref.refers_to)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is mainly changing from ComponentReferenct.hasFeature to ComponentReference.refersTo. Also update the strategy to SO_FORWARD and SO_REVERSE. SBOLTestSuite was updated, and the SHACL rules were updated.

Closes #276 
