### PR TITLE
Ensure namespace is a prefix of identity on object creation

### DIFF
--- a/sbol3/toplevel.py
+++ b/sbol3/toplevel.py
@@ -35,6 +35,10 @@ class TopLevel(Identified):
                          measures=measures)
         if namespace is None:
             namespace = TopLevel.default_namespace(namespace, self.identity)
+        if self._is_url(self.identity) and not self.identity.startswith(namespace):
+            msg = 'Namespace must be a prefix of identity.'
+            msg += f' Namespace {namespace} is not a prefix of {self.identity}.'
+            raise ValueError(msg)
         self.namespace = URIProperty(self, SBOL_NAMESPACE, 1, 1,
                                      initial_value=namespace)
         self.attachments = ReferencedObject(self, SBOL_HAS_ATTACHMENT, 0, math.inf,

--- a/test/test_referenced_object.py
+++ b/test/test_referenced_object.py
@@ -113,7 +113,7 @@ class TestReferencedObject(unittest.TestCase):
         sbol3.set_namespace('https://example.org')
         execution = sbol3.Activity('protocol_execution')
         doc.add(execution)
-        foo = sbol3.Collection('http://example.org/baz')
+        foo = sbol3.Collection('https://example.org/baz')
         foo.members.append(execution)
         # Verify that foo did not get document assigned
         self.assertIsNone(foo.document)

--- a/test/test_toplevel.py
+++ b/test/test_toplevel.py
@@ -79,9 +79,9 @@ class TestTopLevel(unittest.TestCase):
     def test_namespace_mismatch(self):
         # See SBOL 3 rule sbol3-10301
         # See https://github.com/SynBioDex/pySBOL3/issues/278
-        sbol3.set_namespace('http://github.com/synbiodex/pysbol3')
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
         c = sbol3.Component('foo', types=[sbol3.SBO_DNA])
-        c.namespace = 'http://example.com/mismatch'
+        c.namespace = 'https://example.com/mismatch'
         report = c.validate()
         self.assertIsNotNone(report)
         # Expecting at least one error
@@ -99,6 +99,14 @@ class TestTopLevel(unittest.TestCase):
         self.assertIsNotNone(report)
         # Expecting at least one error
         self.assertEqual(len(report), 0)
+
+    def test_creation_namespace_mismatch(self):
+        # Prevent an identity/namespace mismatch on object creation
+        # See https://github.com/SynBioDex/pySBOL3/issues/277
+        with self.assertRaises(ValueError):
+            sbol3.Component('https://example.com/mismatch/c1',
+                            types=[sbol3.SBO_DNA],
+                            namespace='https://example.com/different')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
On object creation if the namespace does not match the identity raise a ValueError to prevent a user from creating an invalid object.

Also correct an errant unit test that had mismatched namespace and identity. Oops!

Fixes #277 