### PR TITLE
Fix Python 3.10 deprecation warnings in build workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,6 +42,6 @@ jobs:
       # disable warnings until we tune to ignore distutils deprecation warning
       run: |
         WARNINGS="-We"
-	PY_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+        PY_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
         if [ "${PY_VERSION}" == "3.10" ]; then echo "Disabling warnings"; WARNINGS=""; fi
         python $WARNINGS -m unittest discover -s test


### PR DESCRIPTION
pyshacl has a warning in python 3.10. Disable warning checking on all platforms for Python 3.10.