### PR TITLE
Remove set_homespace and get_homespace

### DIFF
--- a/sbol3/__init__.py
+++ b/sbol3/__init__.py
@@ -2,8 +2,6 @@ __version__ = '1.0b10'
 
 from .constants import *
 from .config import set_defaults, get_namespace, set_namespace
-# get_homespace and set_homespace are deprecated and included for backward compatibility
-from .config import get_homespace, set_homespace
 from .error import *
 from .validation import *
 from .object import SBOLObject

--- a/sbol3/config.py
+++ b/sbol3/config.py
@@ -31,13 +31,3 @@ def set_defaults() -> None:
 
 
 set_defaults()
-
-
-def set_homespace(homespace: str) -> None:
-    warnings.warn('Use set_namespace instead', DeprecationWarning)
-    return set_namespace(homespace)
-
-
-def get_homespace() -> str:
-    warnings.warn('Use get_namespace instead', DeprecationWarning)
-    return get_namespace()


### PR DESCRIPTION
These functions have been deprecated since the earliest alpha releases.
No programs should be using them. Use set_namespace and get_namespace
instead.

Closes #340