### PR TITLE
Add check for uninitialized identity

### DIFF
--- a/sbol3/refobj_property.py
+++ b/sbol3/refobj_property.py
@@ -32,6 +32,12 @@ class ReferencedObjectMixin:
     @staticmethod
     def from_user(value: Any) -> rdflib.URIRef:
         if isinstance(value, SBOLObject):
+            # see https://github.com/SynBioDex/pySBOL3/issues/357
+            if value.identity is None:
+                # The SBOLObject has an uninitialized identity
+                msg = f'Cannot set reference to {value}.'
+                msg += ' Object identity is uninitialized.'
+                raise ValueError(msg)
             value = value.identity
         if not isinstance(value, str):
             raise TypeError(f'Expecting string, got {type(value)}')

--- a/test/test_referenced_object.py
+++ b/test/test_referenced_object.py
@@ -125,6 +125,15 @@ class TestReferencedObject(unittest.TestCase):
         # to get back to the original instance via document lookup
         self.assertEqual(execution.identity, foo.members[0].lookup().identity)
 
+    def test_no_identity_exception(self):
+        # See https://github.com/SynBioDex/pySBOL3/issues/357
+        sbol3.set_namespace('https://github.com/SynBioDex/pySBOL3')
+        collection = sbol3.Collection('foo_collection')
+        subc = sbol3.SubComponent(instance_of='https://github.com/SynBioDex/pySBOL3/c1')
+        exc_regex = r'Object identity is uninitialized\.$'
+        with self.assertRaisesRegex(ValueError, exc_regex):
+            collection.members.append(subc)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When an object is passed to a referenced object property and its
identity has not yet been initialized then raise an error with a
helpful error message.

Closes #357 