### PR TITLE
Remove @vocab entry from JSON-LD serialization

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -374,7 +374,6 @@ class Document:
             result = self.join_lines(lines)
         elif file_format == JSONLD:
             context = {f'@{prefix}': uri for prefix, uri in self._namespaces.items()}
-            context['@vocab'] = 'https://sbolstandard.org/examples/'
             result = graph.serialize(format=file_format, context=context)
         else:
             result = graph.serialize(format=file_format)

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -430,6 +430,12 @@ class TestDocument(unittest.TestCase):
         doc3 = sbol3.Document()
         doc3.read_string(data, file_format=file_format)
 
+    def test_jsonld_no_vocab(self):
+        # See https://github.com/SynBioDex/pySBOL3/issues/349
+        doc = sbol3.Document()
+        doc_string = doc.write_string(file_format=sbol3.JSONLD)
+        self.assertNotIn('@vocab', doc_string)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The original JSON-LD files had an @vocab entry in the context that
was carried into pySBOL3. The @vocab entry has since been removed.
Remove it from the JSON-LD serialization in pySBOL3.

Closes #349 