### PR TITLE
Incorporate RDFLib JSON-LD fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name='sbol3',
       install_requires=[
             # Require at least rdflib 6.0.1, and allow newer versions
             # of rdflib 6.x
-            'rdflib>=6.0.2,==6.*',
+            'rdflib>=6.1.1,==6.*',
             'python-dateutil~=2.8.2',
             'pyshacl~=0.17.2',
       ],

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -381,7 +381,6 @@ class TestDocument(unittest.TestCase):
         report = doc.validate()
         self.assertEqual(0, len(report))
 
-    @unittest.expectedFailure
     def test_json_ld_parser_bug(self):
         # See https://github.com/RDFLib/rdflib/issues/1443
         # See https://github.com/SynBioDex/pySBOL3/issues/329


### PR DESCRIPTION
RDFLib has fixed the JSON-LD parser bug that adds a trailing slash to
a URL in that is an "object" in a s-p-o triple. Bump the RDFLib
dependency to the version that includes the fix, and remove the
expected failure annotation on the unit test.

See https://github.com/RDFLib/rdflib/issues/1443

Closes #329 
