### PR TITLE
Add `Document.migrate`

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -59,6 +59,27 @@ class Document:
         # SBOL. They are stored in _other_rdf for round-tripping purposes.
         self._other_rdf = rdflib.Graph()
 
+    def __str__(self):
+        """
+        Produce a string representation of the Document.
+
+        :return: A string representation of the Document.
+        """
+        return self.summary()
+
+    def __len__(self):
+        """
+        Get the total number of objects in the Document.
+
+        (Returns the same thing as size())
+
+        :return: The total number of objects in the Document.
+        """
+        return self.size()
+
+    def __contains__(self, item):
+        return item in self.objects
+
     def _build_extension_object(self, identity: str, sbol_type: str,
                                 types: List[str]) -> Optional[Identified]:
         custom_types = {
@@ -579,14 +600,6 @@ class Document:
         summary += str(self.size()) + '\n'
         return summary
 
-    def __str__(self):
-        """
-        Produce a string representation of the Document.
-
-        :return: A string representation of the Document.
-        """
-        return self.summary()
-
     def size(self):
         """
         Get the total number of objects in the Document.
@@ -594,19 +607,6 @@ class Document:
         :return: The total number of objects in the Document.
         """
         return len(self.objects)
-
-    def __len__(self):
-        """
-        Get the total number of objects in the Document.
-
-        (Returns the same thing as size())
-
-        :return: The total number of objects in the Document.
-        """
-        return self.size()
-
-    def __contains__(self, item):
-        return item in self.objects
 
     def remove(self, objects: Iterable[TopLevel]):
         objects_to_remove = []

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -80,6 +80,20 @@ class Document:
     def __contains__(self, item):
         return item in self.objects
 
+    def __iter__(self):
+        """Iterate over the top level objects in this document.
+
+        >>> import sbol3
+        >>> doc = sbol3.Document()
+        >>> doc.read('some_path.ttl')
+        >>> for top_level in doc:
+        >>>     print(top_level.identity)
+
+        :return: An iterator over the top level objects
+        """
+        tmp_list = list(self.objects)
+        return iter(tmp_list)
+
     def _build_extension_object(self, identity: str, sbol_type: str,
                                 types: List[str]) -> Optional[Identified]:
         custom_types = {

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -649,3 +649,24 @@ class Document:
             self.objects.remove(top_level)
         except ValueError:
             pass
+
+    def migrate(self, top_levels: Iterable[TopLevel]) -> Any:
+        """Migrate objects to this document.
+
+        No effort is made to maintain referential integrity. The
+        burden of referential integrity lies with the caller of this
+        method.
+
+        :param top_levels: The top levels to migrate to this document
+        :return: Nothing
+        """
+        objects = []
+        for top_level in top_levels:
+            if not isinstance(top_level, TopLevel):
+                raise ValueError(f"Object {top_level.identity} is not a TopLevel object")
+            objects.append(top_level)
+        # Remove each object from its former document if it has one
+        for obj in objects:
+            obj.remove_from_document()
+        # Add each document to this document
+        self.add(objects)

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -466,12 +466,6 @@ class TestDocument(unittest.TestCase):
         # Test removing some objects, and verify that the document
         # pointers are gone
         sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
-        # test_path = os.path.join(SBOL3_LOCATION, 'toggle_switch',
-        #                          'toggle_switch.ttl')
-        # test_path = os.path.join(SBOL3_LOCATION, 'entity', 'model',
-        #                          'model.ttl')
-        test_path = os.path.join(SBOL3_LOCATION, 'measurement_entity', 'measurement',
-                                 'measurement.ttl')
         test_path = os.path.join(SBOL3_LOCATION, 'multicellular',
                                  'multicellular.ttl')
         doc = sbol3.Document()
@@ -506,6 +500,19 @@ class TestDocument(unittest.TestCase):
             self.assertIsNone(feature.document)
         for constraint in obj2.constraints:
             self.assertIsNone(constraint.document)
+
+    def test_iterable(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
+        test_path = os.path.join(SBOL3_LOCATION, 'multicellular',
+                                 'multicellular.ttl')
+        doc = sbol3.Document()
+        doc.read(test_path)
+        # Make sure the document is iterable
+        self.assertIsNotNone(iter(doc))
+        all_objs = list(doc)
+        # Make sure the objects returned by the iterator match the top
+        # level objects in the document
+        self.assertListEqual(doc.objects, all_objs)
 
 
 if __name__ == '__main__':

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -514,6 +514,18 @@ class TestDocument(unittest.TestCase):
         # level objects in the document
         self.assertListEqual(doc.objects, all_objs)
 
+    def test_migrate(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
+        test_path = os.path.join(SBOL3_LOCATION, 'multicellular',
+                                 'multicellular.ttl')
+        doc = sbol3.Document()
+        doc.read(test_path)
+        orig_len = len(doc)
+        doc2 = sbol3.Document()
+        doc2.migrate(doc)
+        self.assertEqual(orig_len, len(doc2))
+        self.assertEqual(0, len(doc))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`Document.migrate` _moves_ objects into the invoked document. It does not matter if the objects are currently members of a document or not. For objects that are not currently in a document this is equivalent to `Document.add()`. For documents that are in a document, they are removed from that document and added to this one.

Also add `Document.__iter__` to make `Document`s iterable. This allows constructs like:

```python
>>> import sbol3
>>> doc = sbol3.Document()
>>> doc.read('some_path.ttl')
>>> for top_level in doc:
>>>     print(top_level.identity)
```

Related to #235