### PR TITLE
Add `Document.change_object_namespace`

### DIFF
--- a/test/test_document.py
+++ b/test/test_document.py
@@ -526,6 +526,21 @@ class TestDocument(unittest.TestCase):
         self.assertEqual(orig_len, len(doc2))
         self.assertEqual(0, len(doc))
 
+    def test_change_object_namespace(self):
+        namespace = 'https://github.com/synbiodex/pysbol3'
+        sbol3.set_namespace(namespace)
+        test_path = os.path.join(SBOL3_LOCATION, 'multicellular',
+                                 'multicellular.ttl')
+        doc = sbol3.Document()
+        doc.read(test_path)
+        obj = doc.objects[0]
+        old_identity = obj.identity
+        doc.change_object_namespace([obj], namespace)
+        self.assertEqual(namespace, obj.namespace)
+        self.assertNotEqual(old_identity, obj.identity)
+        # TODO: test with a referenced object, like  component with a sequence
+        # TODO: test with a full document of objects, changing the entire document
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -538,8 +538,63 @@ class TestDocument(unittest.TestCase):
         doc.change_object_namespace([obj], namespace)
         self.assertEqual(namespace, obj.namespace)
         self.assertNotEqual(old_identity, obj.identity)
-        # TODO: test with a referenced object, like  component with a sequence
-        # TODO: test with a full document of objects, changing the entire document
+        self.assertTrue(obj.identity.startswith(namespace))
+
+    def test_change_object_namespace_ref(self):
+        # test with a referenced object, like a component with a sequence
+        namespace = 'https://github.com/synbiodex/pysbol3'
+        sbol3.set_namespace(namespace)
+        doc = sbol3.Document()
+        s1 = sbol3.Sequence('s1')
+        c1 = sbol3.Component('c1', types=[sbol3.SBO_DNA], sequences=[s1])
+        doc.add([s1, c1])
+        self.assertEqual(2, len(doc))
+        self.assertEqual(s1.identity, c1.sequences[0])
+        ns2 = 'https://example.com/test_ns'
+        s1_identity = s1.identity
+        c1_identity = c1.identity
+        doc.change_object_namespace([s1, c1], ns2)
+        self.assertEqual(ns2, s1.namespace)
+        self.assertEqual(ns2, c1.namespace)
+        self.assertTrue(s1.identity.startswith(ns2))
+        self.assertTrue(c1.identity.startswith(ns2))
+        self.assertNotEqual(s1_identity, s1.identity)
+        self.assertNotEqual(c1_identity, c1.identity)
+        self.assertEqual(s1.identity, c1.sequences[0])
+
+    def test_change_object_namespace_doc(self):
+        # test with a full document of objects, changing the entire document
+        namespace = 'https://github.com/synbiodex/pysbol3'
+        sbol3.set_namespace(namespace)
+        test_path = os.path.join(SBOL3_LOCATION, 'multicellular',
+                                 'multicellular.ttl')
+        doc = sbol3.Document()
+        doc.read(test_path)
+        doc.change_object_namespace(doc.objects, namespace)
+
+        # Make sure every object has the new namespace
+        def identity_checker(thing: sbol3.Identified):
+            # TopLevel has namespace, Identified does not
+            if hasattr(thing, 'namespace'):
+                self.assertEqual(namespace, thing.namespace)
+            self.assertTrue(thing.identity.startswith(namespace))
+        for obj in doc.objects:
+            obj.traverse(identity_checker)
+
+    def test_change_object_namespace_errors(self):
+        # Test bad arguments, like non-top-levels
+        namespace = 'https://github.com/synbiodex/pysbol3'
+        new_namespace = 'https://example.com/test_ns'
+        sbol3.set_namespace(namespace)
+        doc = sbol3.Document()
+        # Object not in document should raise ValueError
+        c1 = sbol3.Component('c1', types=[sbol3.SBO_DNA])
+        with self.assertRaises(ValueError):
+            doc.change_object_namespace([c1], new_namespace)
+        # Non-TopLevel should raise ValueError
+        i1 = sbol3.Interaction([sbol3.SBO_INHIBITION])
+        with self.assertRaises(ValueError):
+            doc.change_object_namespace([i1], new_namespace)
 
 
 if __name__ == '__main__':

--- a/test/test_toplevel.py
+++ b/test/test_toplevel.py
@@ -131,6 +131,28 @@ class TestTopLevel(unittest.TestCase):
                             types=[sbol3.SBO_DNA],
                             namespace='https://example.com/different')
 
+    def test_split_identity(self):
+        namespace = 'https://github.com/synbiodex/pysbol3'
+        sbol3.set_namespace(namespace)
+        name = 'c1'
+        c1 = sbol3.Component(name, types=[sbol3.SBO_DNA])
+        expected = namespace, '', name
+        self.assertEqual(expected, c1.split_identity())
+        # Test with an intermediate path
+        name = 'c2'
+        path = 'foo'
+        c2_identity = posixpath.join(namespace, path, name)
+        c2 = sbol3.Component(c2_identity, types=[sbol3.SBO_DNA])
+        expected = namespace, path, name
+        self.assertEqual(expected, c2.split_identity())
+        # Test with a longer intermediate path
+        name = 'c3'
+        path = 'foo/bar/baz'
+        c3_identity = posixpath.join(namespace, path, name)
+        c3 = sbol3.Component(c3_identity, types=[sbol3.SBO_DNA])
+        expected = namespace, path, name
+        self.assertEqual(expected, c3.split_identity())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add `Document.change_object_namespace` method to change namespaces of objects. This method maintains referential integrity among the objects whose namespaces are changing.

Related to #235 