### PR TITLE
Provide some stability in dependent names

### DIFF
--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -170,7 +170,7 @@ class Identified(SBOLObject):
                 new_identity = posixpath.join(self.identity, new_display_id)
                 child._update_identity(new_identity, new_display_id)
 
-    def counter_value(self, type_name: str):
+    def counter_value(self, type_name: str) -> int:
         result = 0
         for _, objects in self._owned_objects.items():
             for sibling in objects:

--- a/sbol3/ownedobject.py
+++ b/sbol3/ownedobject.py
@@ -37,7 +37,12 @@ class OwnedObjectPropertyMixin:
         #     raise ValueError(f'Item {item} does not have a display_id')
         type_name = parse_class_name(item.type_uri)
         counter_value = self.property_owner.counter_value(type_name)
-        new_display_id = f'{type_name}{counter_value}'
+        # Provide stability across clone and copy
+        # If an item already has a display_id, use it, otherwise mint a new one
+        if item.display_id:
+            new_display_id = item.display_id
+        else:
+            new_display_id = f'{type_name}{counter_value}'
         new_url = posixpath.join(self.property_owner.identity, new_display_id)
         for sibling in self._storage()[self.property_uri]:
             if sibling == item:

--- a/sbol3/toplevel.py
+++ b/sbol3/toplevel.py
@@ -213,7 +213,7 @@ def make_erase_identity_traverser(identity_map: Dict[str, Identified])\
             return
         identity_map[x.identity] = x
         x._identity = None
-        x._display_id = None
+        # x._display_id = None
         x.document = None
     return erase_identity_traverser
 

--- a/test/test_toplevel.py
+++ b/test/test_toplevel.py
@@ -153,6 +153,25 @@ class TestTopLevel(unittest.TestCase):
         expected = namespace, path, name
         self.assertEqual(expected, c3.split_identity())
 
+    def test_clone_bad_rename(self):
+        # Tests that the dependent objects have consistent renaming
+        namespace = 'https://github.com/synbiodex/pysbol3'
+        sbol3.set_namespace(namespace)
+        name = 'c1'
+        c1 = sbol3.Component(name, types=[sbol3.SBO_DNA])
+        lsc1 = sbol3.LocalSubComponent(types=[sbol3.SBO_DNA])
+        lsc2 = sbol3.LocalSubComponent(types=[sbol3.SBO_DNA])
+        c1.features = [lsc1, lsc2]
+        self.assertEqual('LocalSubComponent1', lsc1.display_id)
+        self.assertEqual('LocalSubComponent2', lsc2.display_id)
+        c1.features.remove(lsc1)
+        self.assertListEqual([lsc2], list(c1.features))
+        self.assertEqual('LocalSubComponent2', lsc2.display_id)
+        self.assertIsNotNone(c1.find('LocalSubComponent2'))
+        clone_name = 'c1_prime'
+        c1_prime = c1.clone(posixpath.join(namespace, clone_name))
+        self.assertIsNotNone(c1_prime.find('LocalSubComponent2'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When top levels are cloned/copied, the dependent objects get renamed and
sometimes this can mean a different name, making it hard to find a
dependent object in the future. Make an attempt at naming stability by
honoring an existing display_id if it exists.