### PR TITLE
Add Document.clone

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -709,3 +709,10 @@ class Document:
             top_level.set_identity(new_identity)
             top_level.update_all_dependents(identity_map)
         return None
+
+    def clone(self) -> List[TopLevel]:
+        """Clone the top level objects in this document.
+
+        :return: A list of cloned TopLevel objects
+        """
+        return [tl.clone() for tl in self]

--- a/sbol3/toplevel.py
+++ b/sbol3/toplevel.py
@@ -138,11 +138,12 @@ class TopLevel(Identified):
         # Set display_id of new object
         self._display_id = self._extract_display_id(self._identity)
 
-    def clone(self, new_identity: str) -> 'TopLevel':
+    def clone(self, new_identity: str = None) -> 'TopLevel':
         obj = copy.deepcopy(self)
         identity_map = {self.identity: obj}
         # Set identity of new object
-        obj.set_identity(new_identity)
+        if new_identity is not None:
+            obj.set_identity(new_identity)
         # Drop the document pointer
         obj.document = None
 

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -596,6 +596,33 @@ class TestDocument(unittest.TestCase):
         with self.assertRaises(ValueError):
             doc.change_object_namespace([i1], new_namespace)
 
+    def test_clone(self):
+        # Test bad arguments, like non-top-levels
+        namespace = 'https://github.com/synbiodex/pysbol3'
+        sbol3.set_namespace(namespace)
+        test_path = os.path.join(SBOL3_LOCATION, 'multicellular',
+                                 'multicellular.ttl')
+        doc = sbol3.Document()
+        doc.read(test_path)
+        # Clone the document
+        clones = doc.clone()
+        # We should have the same number of objects in the clone list
+        self.assertEqual(len(doc), len(clones))
+        # Now spot check the features of an object
+        target_identity = 'https://sbolstandard.org/examples/MulticellularSystem'
+        orig = doc.find(target_identity)
+        clone = None
+        for c in clones:
+            if c.identity == target_identity:
+                clone = c
+                break
+        # Be sure we found the target clone
+        self.assertIsNotNone(clone)
+        orig_feature_identities = [f.identity for f in orig.features]
+        clone_feature_identities = [f.identity for f in clone.features]
+        self.assertEqual(orig_feature_identities, clone_feature_identities)
+        # There are probably more tests we can do...
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Change `TopLevel.clone` to make new_identity optional. This will make `Document.clone` trivial.
* Make `Document.clone` return a list of clones of all `TopLevel` objects in the `Document`.
