### PR TITLE
Update copy documentation, change argument names

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -424,9 +424,9 @@ Copying Documents and Objects
 
 Copying a ``Document`` can result in a few different ends, depending
 on the user's goal. The first option is to create a simple copy of the
-original ``Document``. After copying, the object in the ``Document``
-clone has the same identity as the object in the original
-``Document``.
+original ``Document`` with ``Document.copy``. After copying, the
+object in the ``Document`` clone has the same identity as the object
+in the original ``Document``.
 
 .. code:: python
 
@@ -457,18 +457,19 @@ clone has the same identity as the object in the original
 .. end
 
 
-The ``copy`` function is a more powerful way to copy or clone
-objects. ``Document.copy`` is built on ``copy``. The ``copy`` function
-lets a user copy objects as above. It also lets the user change object
-namespaces and add the new documents to an existing ``Document``.
+The ``sbol3.copy`` function is a more powerful way to copy or clone
+objects. ``Document.copy`` is built on ``sbol3.copy``. The
+``sbol3.copy`` function lets a user copy objects as above. It also
+lets the user change object namespaces and add the new documents to an
+existing ``Document``.
 
 For example, if a user wants to copy objects and change the namespace
-of those objects, a user can use the ``new_namespace`` argument to
-``copy``. Following on from the example above:
+of those objects, a user can use the ``into_namespace`` argument to
+``sbol3.copy``. Following on from the example above:
 
 .. code:: python
 
-    >>> objects = sbol3.copy(doc, new_namespace='https://example.org/foo')
+    >>> objects = sbol3.copy(doc, into_namespace='https://example.org/foo')
     >>> len(objects)
     1
     >>> for o in objects:
@@ -481,15 +482,15 @@ of those objects, a user can use the ``new_namespace`` argument to
 
 Finally, if a user wants to construct a new set of objects and add
 them to an existing ``Document`` they can do so using the
-``new_document`` argument to ``copy``. Again, following on from the
-example above:
+``into_document`` argument to ``sbol3.copy``. Again, following on from
+the example above:
 
 .. code:: python
 
     >>> doc3 = sbol3.Document()
     >>> len(doc3)
     0
-    >>> sbol3.copy(doc, new_namespace='https://example.org/bar', new_document=doc3)
+    >>> sbol3.copy(doc, into_namespace='https://example.org/bar', into_document=doc3)
     [<sbol3.component.Component object at 0x7fb7d844aa60>]
     >>> len(doc3)
     1

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -490,7 +490,8 @@ the example above:
     >>> doc3 = sbol3.Document()
     >>> len(doc3)
     0
-    >>> sbol3.copy(doc, into_namespace='https://example.org/bar', into_document=doc3)
+    >>> # Any iterable of TopLevel can be passed to sbol3.copy:
+    >>> sbol3.copy([cd1], into_namespace='https://example.org/bar', into_document=doc3)
     [<sbol3.component.Component object at 0x7fb7d844aa60>]
     >>> len(doc3)
     1

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -725,13 +725,13 @@ class Document:
                  that are identical to the original objects.
         """
         result = Document()
-        copy(self, new_document=result)
+        copy(self, into_document=result)
         return result
 
 
 def copy(top_levels: Iterable[TopLevel],
-         new_namespace: Optional[str] = None,
-         new_document: Optional[Document] = None) -> List[TopLevel]:
+         into_namespace: Optional[str] = None,
+         into_document: Optional[Document] = None) -> List[TopLevel]:
     """Copy SBOL objects, optionally changing their namespace and
     optionally adding them to a document. Referential integrity among
     the group of provided TopLevel objects is maintained.
@@ -744,8 +744,8 @@ def copy(top_levels: Iterable[TopLevel],
     added to the provided Document.
 
     :param top_levels: Top Level objects to be copied
-    :param new_namespace: A namespace to be given to the new objects
-    :param new_document: A document to which the newly created objects
+    :param into_namespace: A namespace to be given to the new objects
+    :param into_document: A document to which the newly created objects
                          will be added
     :return: A list of the newly created objects
     """
@@ -755,8 +755,8 @@ def copy(top_levels: Iterable[TopLevel],
             raise ValueError(f"Object {top_level.identity} is not a TopLevel object")
         objects.append(top_level)
     clones = [tl.clone() for tl in objects]
-    if new_namespace is not None:
-        Document.change_object_namespace(clones, new_namespace)
-    if new_document is not None:
-        new_document.add(clones)
+    if into_namespace is not None:
+        Document.change_object_namespace(clones, into_namespace)
+    if into_document is not None:
+        into_document.add(clones)
     return clones

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -641,7 +641,7 @@ class TestDocument(unittest.TestCase):
         for obj in copies1:
             obj.traverse(document_checker)
         # Verify that the copies get the new namespace
-        copies2 = sbol3.copy(doc, new_namespace=namespace)
+        copies2 = sbol3.copy(doc, into_namespace=namespace)
         document_checker = self.make_document_checker(None)
         namespace_checker = self.make_namespace_checker(namespace)
         for obj in copies2:
@@ -650,7 +650,7 @@ class TestDocument(unittest.TestCase):
         # Verify new namespace AND new document
         namespace3 = 'https://github.com/synbiodex/pysbol3/copytest'
         doc3 = sbol3.Document()
-        copies3 = sbol3.copy(doc, new_namespace=namespace3, new_document=doc3)
+        copies3 = sbol3.copy(doc, into_namespace=namespace3, into_document=doc3)
         document_checker = self.make_document_checker(doc3)
         namespace_checker = self.make_namespace_checker(namespace3)
         for obj in copies3:


### PR DESCRIPTION
* Change `new_namespace` to `into_namespace`
* Change `new_document` to `into_document`
* Update documentation accordingly
* Show how a list of objects can be used instead of a `Document` with `sbol3.copy`
