### PR TITLE
Add dunder for better representation

### DIFF
--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -75,6 +75,11 @@ class Identified(SBOLObject):
         self._rdf_types = URIProperty(self, RDF_TYPE, 1, math.inf,
                                       initial_value=[type_uri])
 
+    # gets used when object is called through repr() or just "looked at" in a python prompt
+    def __repr__(self) -> str:
+        return '<%s %s>' % (self.__class__.__name__, self.identity)
+
+    # gets used when object is explicity printed
     def __str__(self):
         return '<%s %s>' % (self.__class__.__name__, self.identity)
 


### PR DESCRIPTION
Hi @jakebeal , I was going through this repo to better understand the implementation of the sbol3 standard here which is used in [sbol utilities](https://github.com/SynBioDex/SBOL-utilities), and tried to fix #303 . 
But I noticed that printing `sbol.Component` objects gave a proper output as you described in the latter eg of the issue, however just entering the component object itself, the former non-informative version gets printed. So adding a `__repr__()` method to `Identified` seems to fix this, is this alright?