### PR TITLE
File format to extension function

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -280,7 +280,13 @@ class Document:
         return rdf_format
 
     # Return standard extensions when provided the document's file format
-    def file_extension(self, file_format: str) -> str:
+    @staticmethod
+    def file_extension(file_format: str) -> str:
+        """Return standard extensions when provided the document's file format
+
+        :param file_format: The format of the file
+        :return: A file extension, including the leading '.'
+        """
         # dictionary having keys as valid file formats,
         # and their standard extensions as value
         types_with_standard_extension = {

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -279,7 +279,6 @@ class Document:
             rdf_format = 'nt11'
         return rdf_format
 
-    # Return standard extensions when provided the document's file format
     @staticmethod
     def file_extension(file_format: str) -> str:
         """Return standard extensions when provided the document's file format

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -281,7 +281,8 @@ class Document:
 
     # Return standard extensions when provided the document's file format
     def file_extension(self, file_format: str) -> str:
-        # dictionary having keys as valid file formats and their standard extensions as value
+        # dictionary having keys as valid file formats,
+        # and their standard extensions as value
         types_with_standard_extension = {
             SORTED_NTRIPLES: '.nt',
             NTRIPLES: '.nt',
@@ -291,7 +292,7 @@ class Document:
         }
         if file_format in types_with_standard_extension:
             return types_with_standard_extension[file_format]
-        else: 
+        else:
             raise ValueError('Provided file format is not a valid one.')
 
     # Formats: 'n3', 'nt', 'turtle', 'xml'

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -279,6 +279,21 @@ class Document:
             rdf_format = 'nt11'
         return rdf_format
 
+    # Return standard extensions when provided the document's file format
+    def file_extension(self, file_format: str) -> str:
+        # dictionary having keys as valid file formats and their standard extensions as value
+        types_with_standard_extension = {
+            SORTED_NTRIPLES: '.nt',
+            NTRIPLES: '.nt',
+            JSONLD: '.json',
+            RDF_XML: '.xml',
+            TURTLE: '.ttl'
+        }
+        if file_format in types_with_standard_extension:
+            return types_with_standard_extension[file_format]
+        else: 
+            raise ValueError('Provided file format is not a valid one.')
+
     # Formats: 'n3', 'nt', 'turtle', 'xml'
     def read(self, location: str, file_format: str = None) -> None:
         if file_format is None:

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -38,6 +38,23 @@ class TestDocument(unittest.TestCase):
             self.assertEqual(document, thing.document)
         return document_checker
 
+    def test_file_extension(self):
+        """ Test obtaining standard extensions from file format"""
+        file_format_1 = sbol3.SORTED_NTRIPLES
+        file_format_2 = sbol3.RDF_XML
+        file_format_3 = 'Test_Format'
+        # 1. testing for sorted ntriples
+        extension_1 = sbol3.Document.file_extension(file_format_1)
+        print("1: " + file_format_1 + "Val: "+ extension_1)
+        self.assertEqual(extension_1, '.nt')
+        # 2. testing for rdf xml
+        extension_2 = sbol3.Document.file_extension(file_format_2)
+        print("2: " + file_format_2 + "Val: "+ extension_2)
+        self.assertEqual(extension_2, '.xml')
+        # 3. for invalid file formats, valueError must be raised
+        with self.assertRaises(ValueError):
+            extension_3 = sbol3.Document.file_extension(file_format_3)
+
     def test_read_ntriples(self):
         # Initial test of Document.read
         filename = 'model.nt'

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -45,11 +45,9 @@ class TestDocument(unittest.TestCase):
         file_format_3 = 'Test_Format'
         # 1. testing for sorted ntriples
         extension_1 = sbol3.Document.file_extension(file_format_1)
-        print("1: " + file_format_1 + "Val: "+ extension_1)
         self.assertEqual(extension_1, '.nt')
         # 2. testing for rdf xml
         extension_2 = sbol3.Document.file_extension(file_format_2)
-        print("2: " + file_format_2 + "Val: "+ extension_2)
         self.assertEqual(extension_2, '.xml')
         # 3. for invalid file formats, valueError must be raised
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Hey @tcmitchell  @jakebeal , this tries to fix #244 , by implementing a function bound on the `Document` class to provide standard extensions for given file format.