### PR TITLE
Add PyPy 3.8 to the CI builds

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # Default builds are on Ubuntu
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7']
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8']
         include:
           # Also test on macOS and Windows using latest Python 3
           - os: macos-latest


### PR DESCRIPTION
PyPy released version 3.8 since we added testing with PyPy 3.7. Add PyPy 3.8 to the CI builds.