### PR TITLE
Make `extract_display_id` a top level function

### DIFF
--- a/sbol3/__init__.py
+++ b/sbol3/__init__.py
@@ -14,7 +14,7 @@ from .datetime_property import DateTimeProperty
 from .uri_property import URIProperty
 from .ownedobject import OwnedObject
 from .refobj_property import ReferencedObject
-from .identified import Identified
+from .identified import Identified, extract_display_id, is_valid_display_id
 from .toplevel import TopLevel
 from .custom import CustomIdentified, CustomTopLevel
 from .document import Document, copy

--- a/test/test_identified.py
+++ b/test/test_identified.py
@@ -95,6 +95,13 @@ class TestIdentified(unittest.TestCase):
         self.assertEqual(1, len(thing.derived_from))
         self.assertEqual(process1, thing.derived_from[0])
 
+    def test_extract_display_id(self):
+        # See https://github.com/SynBioDex/pySBOL3/issues/310
+        # Ensure that extract_display_id is a public function
+        self.assertIn('extract_display_id', dir(sbol3))
+        # Ensure that is_valid_display_id is a public function
+        self.assertIn('is_valid_display_id', dir(sbol3))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Pull `Identified.extract_display_id` up to `sbol3.extract_display_id`.
Also change the supporting function `is_valid_display_id` to a public
function because it supports `extract_display_id`.

Closes #310 