### PR TITLE
Made Toplevel.copy() deprecation warning more informative

### DIFF
--- a/sbol3/toplevel.py
+++ b/sbol3/toplevel.py
@@ -171,6 +171,7 @@ class TopLevel(Identified):
         self.traverse(make_update_references_traverser(identity_map))
 
     def copy(self, target_doc=None, target_namespace=None):
+        # Toplevel deprecation warning
         warnings.warn('Toplevel.copy() is deprecated; use sbol3.copy() instead', DeprecationWarning)
         new_obj = super().copy(target_doc=target_doc, target_namespace=target_namespace)
         # Need to set `document` on all children recursively. That's what happens when

--- a/sbol3/toplevel.py
+++ b/sbol3/toplevel.py
@@ -7,6 +7,7 @@ import urllib.parse
 import uuid
 from typing import Dict, Callable, Optional, Any
 import typing
+import warnings
 
 from . import *
 from .typing import *
@@ -170,6 +171,7 @@ class TopLevel(Identified):
         self.traverse(make_update_references_traverser(identity_map))
 
     def copy(self, target_doc=None, target_namespace=None):
+        warnings.warn('Toplevel.copy() is deprecated; use sbol3.copy() instead', DeprecationWarning)
         new_obj = super().copy(target_doc=target_doc, target_namespace=target_namespace)
         # Need to set `document` on all children recursively. That's what happens when
         # you assign to the `document` property of an Identified


### PR DESCRIPTION
Tried to make **deprecation warning more informative** by specifying what has been deprecated
fix #394