### PR TITLE
Make CI builds run on Windows and Mac

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         # Default builds are on Ubuntu
@@ -32,12 +32,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
+      shell: bash
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         python -m pip install .
         python -m pip install 'pycodestyle>=2.6.0'
     - name: Test with unittest
+      shell: bash
       # pyshacl has a 3.10 deprecation warning in distutils
       # disable warnings until we tune to ignore distutils deprecation warning
       run: |


### PR DESCRIPTION
Make the GH Action "python-package" actually run on Windows and Mac
instead of looking like they do while actually running on Ubuntu Linux.

Closes #399 