### PR TITLE
Update Toplevel.copy deprecation warning 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 dist/
 # Emacs backup files
 *~
+test/SBOLTestSuite

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ build/
 dist/
 # Emacs backup files
 *~
-test/SBOLTestSuite

--- a/sbol3/toplevel.py
+++ b/sbol3/toplevel.py
@@ -173,7 +173,7 @@ class TopLevel(Identified):
 
     def copy(self, target_doc=None, target_namespace=None):
         # Delete this method in v1.1
-        warnings.warn('Use sbol3.copy() instead', DeprecationWarning)
+        warnings.warn('Toplevel.copy() is deprecated; use sbol3.copy() instead', DeprecationWarning)
         new_obj = super().copy(target_doc=target_doc, target_namespace=target_namespace)
         # Need to set `document` on all children recursively. That's what happens when
         # you assign to the `document` property of an Identified


### PR DESCRIPTION
Hi @tcmitchell 

I have edited the deprecation warning of Toplevel copy function to be more informative as mention in this issue #394

I have created a new updated branch with the main, so I hope we can merge now.