### PR TITLE
fix typo of URL of sbol data model specification 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 dist/
 # Emacs backup files
 *~
+test/SBOLTestSuite

--- a/sbol3/constants.py
+++ b/sbol3/constants.py
@@ -1,7 +1,7 @@
 # --------------------------------------------------
 # Constants to support SBOL 3
 #
-# See https://sbolstandard.org/data-model-specification/ for the latest version.
+# See https://sbolstandard.org/datamodel-specification/ for the latest version.
 # --------------------------------------------------
 
 SBOL_LOGGER_NAME = 'sbol3'


### PR DESCRIPTION
Inside `constant.py` file the URL of SBOL data model specification is not correct.

I am not sure if it is better to change the URL itself to look like the one written in file or change the one in file for now until next update.

currently this make the URL inside the file send the user to SBOL data model specification website.

fixes #424