### PR TITLE
Add pylint to GitHub workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -47,3 +47,5 @@ jobs:
         PY_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
         if [ "${PY_VERSION}" == "3.10" ]; then echo "Disabling warnings"; WARNINGS=""; fi
         python $WARNINGS -m unittest discover -s test
+        pycodestyle sbol3 test
+        pylint sbol3 test

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,7 +37,7 @@ jobs:
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         python -m pip install .
-        python -m pip install 'pycodestyle>=2.10.0'
+        python -m pip install 'pycodestyle>=2.10.0' 'pylint>=2.17'
     - name: Test with unittest
       shell: bash
       # pyshacl has a 3.10 deprecation warning in distutils

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,55 @@
 # allowing developers to wildly exceed reasonable limits. Not everyone
 # can afford a monstrous wall-sized display.
 max-line-length = 119
+
+[pylint.FORMAT]
+max-line-length = 119
+
+[pylint.MESSAGES CONTROL]
+# Use pylint --rcfile=/dev/null --reports=y to summarize issues and see
+# the low hanging fruit
+disable = abstract-class-instantiated,
+          attribute-defined-outside-init,
+          catching-non-exception,
+          consider-using-generator,
+          consider-using-get,
+          disallowed-name,
+          implicit-str-concat,
+          import-outside-toplevel,
+          logging-not-lazy,
+          consider-using-enumerate,
+          consider-using-f-string,
+          cyclic-import,
+          duplicate-code,
+          fixme,
+          function-redefined,
+          global-statement,
+          inconsistent-return-statements,
+          invalid-name,
+          isinstance-second-argument-not-valid-type,
+          logging-fstring-interpolation,
+          missing-class-docstring,
+          missing-function-docstring,
+          missing-module-docstring,
+          no-else-raise,
+          no-else-return,
+          protected-access,
+          raise-missing-from,
+          redefined-builtin,
+          too-few-public-methods,
+          too-many-arguments,
+          too-many-instance-attributes,
+          too-many-locals,
+          too-many-public-methods,
+          undefined-variable,
+          unidiomatic-typecheck,
+          unnecessary-pass,
+          unspecified-encoding,
+          unused-argument,
+          unused-import,
+          unused-variable,
+          unused-wildcard-import,
+          use-dict-literal,
+          useless-parent-delegation,
+          useless-return,
+          wildcard-import


### PR DESCRIPTION
Configure pylint to ignore a lot in order to get pylint into the workflow. Anticipate improved compatibility over time.

Related to #433 