### PR TITLE
Refactor refobj

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -221,6 +221,12 @@ class Document:
                 if o not in obj._properties[str_p]:
                     obj._properties[str_p].append(o)
             else:
+                # check for referenced objects
+                if type(o) is rdflib.URIRef:
+                    print(obj._properties[str_p])
+                    other_identity = str(o)
+                    if other_identity in objects:
+                        o = objects[other_identity]
                 obj._properties[str_p].append(o)
         return child_objects
 

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -213,6 +213,17 @@ class Document:
                 obj._owned_objects[str_p].append(other)
                 # Record the assigned object as a child
                 child_objects[other_identity] = other
+            elif str_p in obj._referenced_objects:
+                reference = str(o)
+                # A reference may refer to another object
+                # in the current document, or it may be
+                # an external reference to another RDF entity
+                if reference in objects:
+                    other = objects[reference]
+                    obj._referenced_objects[str_p].append(other)
+                else:
+                    # If an external reference, create a base SBOLObject to represent it
+                    obj._referenced_objects[str_p].append(SBOLObject(reference))
             elif str_p == RDF_TYPE:
                 # Handle rdf:type specially because the main type(s)
                 # will already be in the list from the build_object
@@ -221,12 +232,6 @@ class Document:
                 if o not in obj._properties[str_p]:
                     obj._properties[str_p].append(o)
             else:
-                # check for referenced objects
-                if type(o) is rdflib.URIRef:
-                    print(obj._properties[str_p])
-                    other_identity = str(o)
-                    if other_identity in objects:
-                        o = objects[other_identity]
                 obj._properties[str_p].append(o)
         return child_objects
 

--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -269,6 +269,12 @@ class Identified(SBOLObject):
             rdf_prop = rdflib.URIRef(prop)
             for item in items:
                 graph.add((identity, rdf_prop, item))
+        for prop, items in self._referenced_objects.items():
+            if not items:
+                continue
+            rdf_prop = rdflib.URIRef(prop)
+            for item in items:
+                graph.add((identity, rdf_prop, rdflib.URIRef(item.identity)))
         for prop, items in self._owned_objects.items():
             if not items:
                 continue

--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -106,6 +106,20 @@ class SBOLObject:
                     return result
         return None
 
+    def _resolve_references(self, new_obj):
+        NEW_OBJ = new_obj
+        def resolve_references(x):
+            for property_id, references in x._referenced_objects.items():
+                needs_updating = False
+                for ref_obj in references:
+                    if ref_obj.identity == NEW_OBJ.identity:
+                        needs_updating = True
+                        break
+                if needs_updating:
+                    references.remove(ref_obj)
+                    references.append(new_obj)
+        self.traverse(resolve_references)
+
     def copy(self, target_doc=None, target_namespace=None):
 
         # Delete this method in v1.1

--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -19,6 +19,7 @@ class SBOLObject:
         # Could it be an attribute that gets composed on the fly? Keep it simple for
         # now, and change to a property in the future if needed.
         self._identity = SBOLObject._make_identity(name)
+        self._references = []
 
     def __setattr__(self, name, value):
         try:

--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -149,6 +149,8 @@ class SBOLObject:
 
         return new_obj
 
+    def lookup(self):
+        return self
 
 def replace_namespace(old_uri, target_namespace, rdf_type):
 

--- a/sbol3/object.py
+++ b/sbol3/object.py
@@ -37,6 +37,14 @@ class SBOLObject:
             result = result.get()
         return result
 
+    def __eq__(self, other):
+        if type(other) is str:
+            return self.identity == other
+        return super().__eq__(other)
+
+    def __hash__(self):
+        return hash(self.identity)
+
     @staticmethod
     def _is_url(name: str) -> bool:
         parsed = urlparse(name)

--- a/sbol3/property_base.py
+++ b/sbol3/property_base.py
@@ -175,7 +175,10 @@ class ListProperty(Property, MutableSequence, abc.ABC):
             msg = f'{name} requires one or more values'
             msg += ' packed in an iterable'
             raise TypeError(msg)
-        items = [self.from_user(v) for v in value]
+        try:
+            items = [self.from_user(v) for v in value]
+        except Exception as e:
+            print(e)
         self._storage()[self.property_uri] = items
         for val in value:
             self.item_added(val)

--- a/sbol3/refobj_property.py
+++ b/sbol3/refobj_property.py
@@ -115,6 +115,10 @@ class ReferencedObjectList(ReferencedObjectMixin, ListProperty):
         super().__delitem__(key)
 
     def set(self, value: Any) -> None:
+        # If the current value of the property
+        # is identical to the value being set, do nothing.
+        if value == self._storage()[self.property_uri]:
+            return
         for o in self._storage()[self.property_uri]:
             o._references.remove(self.property_owner)
         super().set(value)

--- a/sbol3/refobj_property.py
+++ b/sbol3/refobj_property.py
@@ -41,13 +41,16 @@ class ReferencedObjectMixin:
         if type(value) is str:
             if self.property_owner.document:
                 referenced_obj = self.property_owner.document.find(value)
-                # TODO: warn user referenced object is not in document
                 if referenced_obj is not None:
+                    # Keep track of this reference to the object
                     if self not in referenced_obj._references:
                         referenced_obj._references += [self.property_owner]
                     return referenced_obj
-            # If not found in Document
+            # The given URI refers to an object not currently in this
+            # Document, so create a stub
+            # TODO: warn user referenced object is not in document
             value = SBOLObject(value)
+
         if not isinstance(value, SBOLObject):
             raise TypeError('Cannot set property, the value must be str or instance of SBOLObect')
         if value.identity is None:
@@ -55,6 +58,7 @@ class ReferencedObjectMixin:
             msg = f'Cannot set reference to {value}.'
             msg += ' Object identity is uninitialized.'
             raise ValueError(msg)
+        # Keep track of this reference to the object
         value._references += [self.property_owner]
         return value
 

--- a/sbol3/refobj_property.py
+++ b/sbol3/refobj_property.py
@@ -25,6 +25,10 @@ class ReferencedObjectMixin:
     def _storage(self) -> Dict[str, list]:
         return self.property_owner._referenced_objects
 
+    def _clear(self):
+        for obj in self._storage()[self.property_uri]:
+            obj._references = []
+
     def to_user(self, value: Any) -> str:
         if hasattr(self, 'property_owner'):
             parent = self.property_owner
@@ -32,25 +36,15 @@ class ReferencedObjectMixin:
         # Should we check to see if value has a document as well?
         return value
 
-    #@staticmethod
     def from_user(self, value: Any) -> rdflib.URIRef:
-        #if isinstance(value, SBOLObject):
-        #    # see https://github.com/SynBioDex/pySBOL3/issues/357
-        #    if value.identity is None:
-        #        # The SBOLObject has an uninitialized identity
-        #        msg = f'Cannot set reference to {value}.'
-        #        msg += ' Object identity is uninitialized.'
-        #        raise ValueError(msg)
-        #    value = value.identity
-        #if not isinstance(value, str):
-        #    raise TypeError(f'Expecting string, got {type(value)}')
-
         # TODO: what is value is empty string?
         if type(value) is str:
             if self.property_owner.document:
                 referenced_obj = self.property_owner.document.find(value)
                 # TODO: warn user referenced object is not in document
                 if referenced_obj is not None:
+                    if self not in referenced_obj._references:
+                        referenced_obj._references += [self.property_owner]
                     return referenced_obj
             # If not found in Document
             value = SBOLObject(value)
@@ -61,6 +55,7 @@ class ReferencedObjectMixin:
             msg = f'Cannot set reference to {value}.'
             msg += ' Object identity is uninitialized.'
             raise ValueError(msg)
+        value._references += [self.property_owner]
         return value
 
     def maybe_add_to_document(self, value: Any) -> None:
@@ -87,6 +82,8 @@ class ReferencedObjectSingleton(ReferencedObjectMixin, SingletonProperty):
             self.set(initial_value)
 
     def set(self, value: Any) -> None:
+        for o in self._storage()[self.property_uri]:
+            o._references.remove(self.property_owner)
         super().set(value)
         # See bug 184 - don't add to document
         # self.maybe_add_to_document(value)
@@ -106,6 +103,21 @@ class ReferencedObjectList(ReferencedObjectMixin, ListProperty):
                 # Wrap the singleton in a list
                 initial_value = [initial_value]
             self.set(initial_value)
+
+    def __setitem__(self, key: Union[int, slice], value: Any) -> None:
+        replaced_obj = self._storage()[self.property_uri].__getitem__(key)
+        replaced_obj._references.remove(self.property_owner) 
+        super().__setitem__(key, value)
+
+    def __delitem__(self, key: Union[int, slice]) -> None:
+        replaced_item = self._storage()[self.property_uri][key]
+        replaced_item._references.remove(self.property_owner)
+        super().__delitem__(key)
+
+    def set(self, value: Any) -> None:
+        for o in self._storage()[self.property_uri]:
+            o._references.remove(self.property_owner)
+        super().set(value)
 
     # See bug 184 - don't add to document
     # def item_added(self, item: Any) -> None:

--- a/sbol3/refobj_property.py
+++ b/sbol3/refobj_property.py
@@ -23,25 +23,37 @@ class ReferencedURI(str):
 class ReferencedObjectMixin:
 
     def to_user(self, value: Any) -> str:
-        result = ReferencedURI(str(value))
         if hasattr(self, 'property_owner'):
             parent = self.property_owner
-            result.parent = parent
-        return result
+            value.parent = parent
+        # Should we check to see if value has a document as well?
+        return value
 
-    @staticmethod
-    def from_user(value: Any) -> rdflib.URIRef:
-        if isinstance(value, SBOLObject):
-            # see https://github.com/SynBioDex/pySBOL3/issues/357
-            if value.identity is None:
-                # The SBOLObject has an uninitialized identity
-                msg = f'Cannot set reference to {value}.'
-                msg += ' Object identity is uninitialized.'
-                raise ValueError(msg)
-            value = value.identity
-        if not isinstance(value, str):
-            raise TypeError(f'Expecting string, got {type(value)}')
-        return rdflib.URIRef(value)
+    #@staticmethod
+    def from_user(self, value: Any) -> rdflib.URIRef:
+        #if isinstance(value, SBOLObject):
+        #    # see https://github.com/SynBioDex/pySBOL3/issues/357
+        #    if value.identity is None:
+        #        # The SBOLObject has an uninitialized identity
+        #        msg = f'Cannot set reference to {value}.'
+        #        msg += ' Object identity is uninitialized.'
+        #        raise ValueError(msg)
+        #    value = value.identity
+        #if not isinstance(value, str):
+        #    raise TypeError(f'Expecting string, got {type(value)}')
+
+        # TODO: what is value is empty string?
+        if type(value) is str:
+            if self.property_owner.document:
+                value = self.property_owner.document.find(value)
+                # TODO: warn user referenced object is not in document
+                if value is not None:
+                    return value
+            # If not found in Document
+            value = SBOLObject(value)
+        if not isinstance(value, SBOLObject):
+            raise TypeError('Cannot set property, the value must be str or instance of SBOLObect')
+        return value
 
     def maybe_add_to_document(self, value: Any) -> None:
         # if not isinstance(value, TopLevel):

--- a/sbol3/refobj_property.py
+++ b/sbol3/refobj_property.py
@@ -22,6 +22,9 @@ class ReferencedURI(str):
 
 class ReferencedObjectMixin:
 
+    def _storage(self) -> Dict[str, list]:
+        return self.property_owner._referenced_objects
+
     def to_user(self, value: Any) -> str:
         if hasattr(self, 'property_owner'):
             parent = self.property_owner
@@ -45,14 +48,19 @@ class ReferencedObjectMixin:
         # TODO: what is value is empty string?
         if type(value) is str:
             if self.property_owner.document:
-                value = self.property_owner.document.find(value)
+                referenced_obj = self.property_owner.document.find(value)
                 # TODO: warn user referenced object is not in document
-                if value is not None:
-                    return value
+                if referenced_obj is not None:
+                    return referenced_obj
             # If not found in Document
             value = SBOLObject(value)
         if not isinstance(value, SBOLObject):
             raise TypeError('Cannot set property, the value must be str or instance of SBOLObect')
+        if value.identity is None:
+            # The SBOLObject has an uninitialized identity
+            msg = f'Cannot set reference to {value}.'
+            msg += ' Object identity is uninitialized.'
+            raise ValueError(msg)
         return value
 
     def maybe_add_to_document(self, value: Any) -> None:

--- a/test/test_referenced_object.py
+++ b/test/test_referenced_object.py
@@ -21,6 +21,20 @@ class SingleRefObj(sbol3.TopLevel):
 
 class TestReferencedObject(unittest.TestCase):
 
+    TEST_SBOL = '''
+@base          <https://sbolstandard.org/examples/> .
+@prefix :      <https://sbolstandard.org/examples/> .
+@prefix sbol:  <http://sbols.org/v3#> .
+@prefix SBO:   <https://identifiers.org/SBO:> .
+
+:toggle_switch  a          sbol:Component ;
+        sbol:description   "Toggle Switch genetic circuit" ;
+        sbol:displayId     "toggle_switch" ;
+        sbol:hasModel      :model1 ;
+        sbol:hasNamespace  <https://sbolstandard.org/examples> ;
+        sbol:name          "Toggle Switch" ;
+        sbol:type          SBO:0000241 .'''
+
     def setUp(self) -> None:
         sbol3.set_defaults()
 
@@ -48,24 +62,10 @@ class TestReferencedObject(unittest.TestCase):
     def test_parse_external_reference(self):
         # When parsing a document, if we encounter a reference to an object 
         # not in this document, create a stub object using SBOLObject
-        test_sbol='''
-@base          <https://sbolstandard.org/examples/> .
-@prefix :      <https://sbolstandard.org/examples/> .
-@prefix sbol:  <http://sbols.org/v3#> .
-@prefix SBO:   <https://identifiers.org/SBO:> .
-
-:toggle_switch  a          sbol:Component ;
-        sbol:description   "Toggle Switch genetic circuit" ;
-        sbol:displayId     "toggle_switch" ;
-        sbol:hasModel      :model1 ;
-        sbol:hasNamespace  <https://sbolstandard.org/examples> ;
-        sbol:name          "Toggle Switch" ;
-        sbol:type          SBO:0000241 .
-'''
         test_format = sbol3.TURTLE
 
         doc = sbol3.Document()
-        doc.read_string(test_sbol, file_format=test_format)
+        doc.read_string(TestReferencedObject.TEST_SBOL, file_format=test_format)
         component = doc.find('toggle_switch')
         model = component.models[0]
         self.assertTrue(type(model) is sbol3.SBOLObject)
@@ -74,26 +74,12 @@ class TestReferencedObject(unittest.TestCase):
     def test_serialize_external_reference(self):
         # When serializing a document, if we encounter a reference to an object 
         # not in this document, serialize it as a URI
-        test_sbol='''
-@base          <https://sbolstandard.org/examples/> .
-@prefix :      <https://sbolstandard.org/examples/> .
-@prefix sbol:  <http://sbols.org/v3#> .
-@prefix SBO:   <https://identifiers.org/SBO:> .
-
-:toggle_switch  a          sbol:Component ;
-        sbol:description   "Toggle Switch genetic circuit" ;
-        sbol:displayId     "toggle_switch" ;
-        sbol:hasModel      :model1 ;
-        sbol:hasNamespace  <https://sbolstandard.org/examples> ;
-        sbol:name          "Toggle Switch" ;
-        sbol:type          SBO:0000241 .
-'''
         test_format = sbol3.TURTLE
 
         doc = sbol3.Document()
         doc2 = sbol3.Document()
 
-        doc.read_string(test_sbol, file_format=test_format)
+        doc.read_string(TestReferencedObject.TEST_SBOL, file_format=test_format)
         component = doc.find('toggle_switch')
         model = component.models[0]
         self.assertTrue(type(model) is sbol3.SBOLObject)

--- a/test/test_referenced_object.py
+++ b/test/test_referenced_object.py
@@ -133,6 +133,7 @@ class TestReferencedObject(unittest.TestCase):
         doc.add(component)
         doc.add(seq1)
         doc.add(seq2)
+
         component.sequences.append(seq1.identity)
         self.assertEqual(seq1, component.sequences[0])
         component.sequences = [seq1.identity]
@@ -240,6 +241,46 @@ class TestReferencedObject(unittest.TestCase):
         self.assertEqual(foo, foo.identity)
         self.assertEqual(foo.identity, foo)
  
+    def test_singleton_property_reference_counter(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
+        doc = sbol3.Document()
+        root = sbol3.Component('root', sbol3.SBO_DNA)
+        sub = sbol3.Component('sub', sbol3.SBO_DNA)
+
+        doc.add(root)
+        doc.add(sub)
+
+        feature = sbol3.SubComponent(instance_of=root)
+        root.features.append(feature)
+        self.assertEqual(root._references, [feature])
+
+    def test_list_property_reference_counter(self):
+        sbol3.set_namespace('https://github.com/synbiodex/pysbol3')
+        doc = sbol3.Document()
+        component = sbol3.Component('c1', sbol3.SBO_DNA)
+
+        # Test that the reference counter is initialized
+        seq1 = sbol3.Sequence('seq1')
+        self.assertListEqual(seq1._references, [])
+        doc.add(component)
+        doc.add(seq1)
+        
+        # Test that the reference counter is working
+        component.sequences = [seq1.identity]
+        self.assertListEqual(seq1._references, [component])
+
+        # Test that the reference counter is cleared
+        component.sequences = []
+        self.assertListEqual(seq1._references, [])
+
+        # Test that the reference counter works with the append method
+        component.sequences.append(seq1.identity)
+        self.assertListEqual(seq1._references, [component])
+
+        # Test that the reference counter is cleared
+        component.sequences.remove(seq1)
+        self.assertListEqual(seq1._references, [])
+
     def test_update(self):
         # Update and resolve references to an external object when the object is
         # added to the Document

--- a/test/test_referenced_object.py
+++ b/test/test_referenced_object.py
@@ -233,6 +233,17 @@ class TestReferencedObject(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, exc_regex):
             collection.members.append(subc)
 
+    def test_equality(self):
+        # Test comparison of a referenced object to a URI, in order
+        # to maintain reverse compatibility
+        foo = sbol3.SBOLObject('foo')
+        self.assertEqual(foo, foo.identity)
+        self.assertEqual(foo.identity, foo)
+ 
+    def test_update(self):
+        # Update and resolve references to an external object when the object is
+        # added to the Document
+        pass
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This experimental feature branch aims to eliminate costly lookup operations.  It was motivated by the fact that LabOP protocols, even relatively simple ones, start to bog down during protocol execution.  Profiling showed that execution was getting bogged down by `lookups` and `finds` that take a long time to traverse over the Document tree.  As the protocol executes, new objects are dynamically generated, making these document traversals ever more costly.  Moreover, a conventional caching approach (e.g., Python `functools`) was ineffective, as the lookups are predominantly performed on nascent, uncached objects.

- `ReferencedObject` attributes have been refactored so that a `ReferencedObject` attribute will _always_ return an object, not a URI 
- Thus `ReferencedObject` attributes always contain direct pointers to Python objects in memory; no document traversal is required to dereference the object
- When a `ReferencedObject` refers to an external object not currently contained in the `Document`, a stub `SBOLObject` is used instead
- Implements rudimentary reference counter/garbage collection (for lack of better words)
- Almost maintains reverse compatibility (almost)