### PR TITLE
Update compatible python versions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,12 +40,13 @@ jobs:
         python -m pip install 'pycodestyle>=2.10.0' 'pylint>=2.17'
     - name: Test with unittest
       shell: bash
-      # pyshacl has a 3.10 deprecation warning in distutils
-      # disable warnings until we tune to ignore distutils deprecation warning
+      # Python 3.12 has lots of deprecation warnings about
+      # datetime.datetime.utcfromtimestamp in the standard library.
+      # disable warnings checks for python 3.12.
       run: |
         WARNINGS="-We"
         PY_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-        if [ "${PY_VERSION}" == "3.10" ]; then echo "Disabling warnings"; WARNINGS=""; fi
+        if [ "${PY_VERSION}" == "3.12" ]; then echo "Disabling warnings"; WARNINGS=""; fi
         python $WARNINGS -m unittest discover -s test
         pycodestyle sbol3 test
         pylint sbol3 test

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # Default builds are on Ubuntu
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
         include:
           # Also test on macOS and Windows using latest Python 3
           - os: macos-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # Default builds are on Ubuntu
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
         include:
           # Also test on macOS and Windows using latest Python 3
           - os: macos-latest

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(name='sbol3',
       version='1.2',
       description='Python implementation of SBOL 3 standard',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       url='https://github.com/SynBioDex/pySBOL3',
       author='Tom Mitchell',
       author_email='tcmitchell@users.noreply.github.com',
@@ -25,11 +25,11 @@ setup(name='sbol3',
             # Specify the Python versions you support here. In particular, ensure
             # that you indicate whether you support Python 2, Python 3 or both.
             'Programming Language :: Python :: 3 :: Only',
-            'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
+            'Programming Language :: Python :: 3.12',
       ],
       # What does your project relate to?
       keywords='synthetic biology',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(name='sbol3',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
-            'Programming Language :: Python :: 3.12',
       ],
       # What does your project relate to?
       keywords='synthetic biology',

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ setup(name='sbol3',
             # of rdflib 6.x
             'rdflib>=6.1.1,==6.*',
             'python-dateutil~=2.8.2',
-            'pyshacl~=0.21',
+            'pyshacl~=0.23',
       ],
       test_suite='test',
       tests_require=[
-            'pycodestyle~=2.10'
+            'pycodestyle~=2.11'
       ])


### PR DESCRIPTION
Drop support for Python 3.7 because it is end of life. Add support for pypy 3.10.

Closes #442 