### PR TITLE
Patch #444 by rolling back Windows/Mac python version

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,9 +20,9 @@ jobs:
         include:
           # Also test on macOS and Windows using latest Python 3
           - os: macos-latest
-            python-version: '3.x'
+            python-version: '3.11'  # Return to 3.x after resolution of https://github.com/RDFLib/pySHACL/issues/212
           - os: windows-latest
-            python-version: '3.x'
+            python-version: '3.11'  # Return to 3.x after resolution of https://github.com/RDFLib/pySHACL/issues/212
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Roll back Windows and Mac builds to Python 3.11 as a workaround for https://github.com/RDFLib/pySHACL/issues/212

This does not fix the issue, but should nullify it until the root issue on pySHACL is addressed.