### PR TITLE
updated doc.read to include the appropriate path to simple_library.nt

### DIFF
--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -10,7 +10,8 @@
     "import sbol3\n",
     "\n",
     "import os\n",
-    "import glob"
+    "import glob\n",
+    "import pathlib"
    ]
   },
   {
@@ -30,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "doc.read('simple_library.nt')"
+    "doc.read(pathlib.Path.cwd().parent / 'test' / 'resources' / 'simple_library.nt')"
    ]
   },
   {


### PR DESCRIPTION
Hey @jakebeal . This is a pull request for the issue #446 about rectifying the path to simple_library.nt in the file /examples/getting_started.ipynb

Thank You.

Closes #446 