### PR TITLE
Fix pylint warnings and quite unit test logging

### DIFF
--- a/sbol3/identified.py
+++ b/sbol3/identified.py
@@ -211,9 +211,7 @@ class Identified(SBOLObject):
             for sibling in objects:
                 if sibling.display_id and sibling.display_id.startswith(type_name):
                     counter_string = sibling.display_id[len(type_name):]
-                    counter_int = int(counter_string)
-                    if counter_int > result:
-                        result = counter_int
+                    result = max(result, int(counter_string))
         return result + 1
 
     @property

--- a/sbol3/validation.py
+++ b/sbol3/validation.py
@@ -45,10 +45,8 @@ class ValidationReport:
         return len(self._errors) + len(self._warnings)
 
     def __iter__(self):
-        for error in self._errors:
-            yield error
-        for warning in self._warnings:
-            yield warning
+        yield from self._errors
+        yield from self._warnings
 
     def __str__(self):
         issues = self._errors + self._warnings

--- a/test/test_custom.py
+++ b/test/test_custom.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import os
 import tempfile
@@ -106,7 +107,8 @@ class TestCustomTopLevel(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdirname:
             test_file = os.path.join(tmpdirname, 'custom.nt')
             doc.write(test_file, sbol3.NTRIPLES)
-            doc2.read(test_file, sbol3.NTRIPLES)
+            with self.assertLogs(level=logging.WARNING):
+                doc2.read(test_file, sbol3.NTRIPLES)
         obj2 = doc2.find(obj_name)
         obj_u2 = doc2.find(obj_unregistered_name)
         # The lists are necessarily unordered because of RDF
@@ -120,7 +122,8 @@ class TestCustomTopLevel(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             obj2.copy(doc3)
-            obj_u2.copy(doc3)
+            with self.assertLogs(level=logging.WARNING):
+                obj_u2.copy(doc3)
         obj3 = doc3.find(obj_name)
         obj_u3 = doc3.find(obj_unregistered_name)
         # The lists are necessarily unordered because of RDF

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -366,7 +366,8 @@ class TestDocument(unittest.TestCase):
         # rdf:type properties
         test_file = os.path.join(TEST_RESOURCE_DIR, 'multi-type-ext.nt')
         doc = sbol3.Document()
-        doc.read(test_file)
+        with self.assertLogs(level=logging.WARNING):
+            doc.read(test_file)
         uri = 'http://example.com/sbol3/c1'
         x = doc.find(uri)
         self.assertIsNotNone(x)

--- a/test/test_feature.py
+++ b/test/test_feature.py
@@ -1,3 +1,4 @@
+import logging
 import unittest
 
 import sbol3
@@ -25,7 +26,8 @@ class TestFeature(unittest.TestCase):
         ptet = sbol3.Component('pTetR', sbol3.SBO_DNA, roles=[sbol3.SO_PROMOTER])
         circuit = sbol3.Component('circuit', sbol3.SBO_DNA, roles=[sbol3.SO_ENGINEERED_REGION])
         # orientation should be an item from this list [SO_FORWARD, SO_REVERSE, SBOL_INLINE, SBOL_REVERSE_COMPLEMENT]
-        ptet_sc = sbol3.SubComponent(ptet, orientation='Wrong Orientation')
+        with self.assertLogs(level=logging.WARNING):
+            ptet_sc = sbol3.SubComponent(ptet, orientation='Wrong Orientation')
         circuit.features += [ptet_sc]
         report = ptet_sc.validate()
         self.assertEqual(1, len(report))

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -65,8 +65,7 @@ class TestRoundTrip(unittest.TestCase):
         for item in os.listdir(dirname):
             item_path = os.path.join(dirname, item)
             if os.path.isdir(item_path):
-                for f in self.find_all_files(item_path):
-                    yield f
+                yield from self.find_all_files(item_path)
             elif os.path.isfile(item_path):
                 yield item_path
             else:

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -96,19 +96,20 @@ class TestRoundTrip(unittest.TestCase):
         # This was an early test, before the library was complete and
         # the files could be round tripped.
         skip_list = self.skip_reading
-        for f in self.find_all_files(SBOL3_LOCATION):
-            basename = os.path.basename(f)
-            if os.path.splitext(basename)[0] in skip_list:
-                # print(f'Skipping {f}')
-                continue
-            rdf_type = self.rdf_type(f)
-            if rdf_type is None:
-                # Skip file types we don't know
-                # print(f'Skipping {f} of type {rdf_type}')
-                continue
-            # print(f'Reading {f}')
-            doc = sbol3.Document()
-            doc.read(f, rdf_type)
+        with self.assertLogs(level=logging.WARNING):
+            for f in self.find_all_files(SBOL3_LOCATION):
+                basename = os.path.basename(f)
+                if os.path.splitext(basename)[0] in skip_list:
+                    # print(f'Skipping {f}')
+                    continue
+                rdf_type = self.rdf_type(f)
+                if rdf_type is None:
+                    # Skip file types we don't know
+                    # print(f'Skipping {f} of type {rdf_type}')
+                    continue
+                # print(f'Reading {f}')
+                doc = sbol3.Document()
+                doc.read(f, rdf_type)
 
     def run_round_trip_file(self, test_path, file_format):
         """Runs a round trip test on the file at the given path.
@@ -160,18 +161,19 @@ class TestRoundTrip(unittest.TestCase):
     def test_sbol3_files(self):
         test_dir = SBOL3_LOCATION
         skip_list = self.skip_round_trip
-        for test_file in self.find_all_files(test_dir):
-            basename = os.path.basename(test_file)
-            if os.path.splitext(basename)[0] in skip_list:
-                self.logger.debug(f'Skipping {test_file}')
-                continue
-            file_format = self.rdf_type(test_file)
-            if not file_format:
-                continue
-            with self.subTest(filename=test_file):
-                self.setUp()
-                self.run_round_trip_file(test_file, file_format)
-                self.tearDown()
+        with self.assertLogs(level=logging.WARNING):
+            for test_file in self.find_all_files(test_dir):
+                basename = os.path.basename(test_file)
+                if os.path.splitext(basename)[0] in skip_list:
+                    self.logger.debug(f'Skipping {test_file}')
+                    continue
+                file_format = self.rdf_type(test_file)
+                if not file_format:
+                    continue
+                with self.subTest(filename=test_file):
+                    self.setUp()
+                    self.run_round_trip_file(test_file, file_format)
+                    self.tearDown()
 
     def test_mixed_rdf(self):
         # See https://github.com/SynBioDex/pySBOL3/issues/96
@@ -188,7 +190,8 @@ class TestRoundTrip(unittest.TestCase):
         # Load a file that includes an SBOL object that has multiple other
         # rdf:type properties
         test_file = os.path.join(TEST_RESOURCE_DIR, 'multi-type-ext.nt')
-        self.run_round_trip_file(test_file, sbol3.NTRIPLES)
+        with self.assertLogs(level=logging.WARNING):
+            self.run_round_trip_file(test_file, sbol3.NTRIPLES)
 
     def test_multi_type_ext_builder(self):
         class MultiTypeExtension(sbol3.TopLevel):


### PR DESCRIPTION
* Follow recommendations of updated pylint to use built-in `max` and to use `yield from`.
* Quiet unit test logging using self.assertLogs()

Closes #450 