### PR TITLE
Replaced wild card imports

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -206,7 +206,7 @@ class Document:
     def _parse_attributes(objects, graph) -> dict[str, Identified]:
         # Track the child objects that get assigned to optimize the
         # search for orphans later in the loading process.
-        child_objects = dict()
+        child_objects = {}
         for s, p, o in graph.triples((None, None, None)):
             str_s = str(s)
             str_p = str(p)

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -4,19 +4,27 @@ import collections
 import logging
 import os
 import posixpath
-import warnings
-from pathlib import Path
-from typing import Dict, Callable, List, Optional, Any, Union, Iterable
-
 # import typing for typing.Sequence, which we don't want to confuse
 # with sbol3.Sequence
 import typing as pytyping
+import warnings
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
 import pyshacl
 import rdflib
 
-from . import *
-from .object import BUILDER_REGISTER
+from .constants import (JSONLD, NTRIPLES, OM_NS, PROV_NS, RDF_TYPE, RDF_XML,
+                        SBOL3_NS, SBOL_IDENTIFIED, SBOL_LOGGER_NAME,
+                        SBOL_NAMESPACE, SBOL_TOP_LEVEL, SORTED_NTRIPLES,
+                        TURTLE)
+from .custom import CustomIdentified, CustomTopLevel
+from .error import SBOLError
+from .identified import Identified
+from .object import BUILDER_REGISTER, SBOLObject
+from .property_base import SingletonProperty
+from .toplevel import TopLevel
+from .validation import ValidationReport
 
 _default_bindings = {
     'sbol': SBOL3_NS,

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -16,8 +16,7 @@ import rdflib
 
 from .constants import (JSONLD, NTRIPLES, OM_NS, PROV_NS, RDF_TYPE, RDF_XML,
                         SBOL3_NS, SBOL_IDENTIFIED, SBOL_LOGGER_NAME,
-                        SBOL_NAMESPACE, SBOL_TOP_LEVEL, SORTED_NTRIPLES,
-                        TURTLE)
+                        SBOL_NAMESPACE, SBOL_TOP_LEVEL, SORTED_NTRIPLES)
 from .custom import CustomIdentified, CustomTopLevel
 from .error import SBOLError
 from .identified import Identified
@@ -169,9 +168,9 @@ class Document:
         else:
             try:
                 builder = self._uri_type_map[sbol_type]
-            except KeyError:
+            except KeyError as exc:
                 logging.warning(f'No builder found for {sbol_type}')
-                raise SBOLError(f'Unknown type {sbol_type}')
+                raise SBOLError(f'Unknown type {sbol_type}') from exc
             result = builder(identity=identity, type_uri=sbol_type)
         # Fix https://github.com/SynBioDex/pySBOL3/issues/264
         if isinstance(result, TopLevel):
@@ -322,10 +321,9 @@ class Document:
             RDF_XML: '.xml',
             TURTLE: '.ttl'
         }
-        if file_format in types_with_standard_extension:
-            return types_with_standard_extension[file_format]
-        else:
+        if not file_format in types_with_standard_extension:
             raise ValueError('Provided file format is not a valid one.')
+        return types_with_standard_extension[file_format]
 
     # Formats: 'n3', 'nt', 'turtle', 'xml'
     def read(self, location: Union[Path, str], file_format: str = None) -> None:

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -16,7 +16,8 @@ import rdflib
 
 from .constants import (JSONLD, NTRIPLES, OM_NS, PROV_NS, RDF_TYPE, RDF_XML,
                         SBOL3_NS, SBOL_IDENTIFIED, SBOL_LOGGER_NAME,
-                        SBOL_NAMESPACE, SBOL_TOP_LEVEL, SORTED_NTRIPLES)
+                        SBOL_NAMESPACE, SBOL_TOP_LEVEL, SORTED_NTRIPLES,
+                        TURTLE)
 from .custom import CustomIdentified, CustomTopLevel
 from .error import SBOLError
 from .identified import Identified

--- a/sbol3/location.py
+++ b/sbol3/location.py
@@ -1,8 +1,17 @@
 import abc
-from typing import Union, Any, Optional
+from typing import Any, Optional, Union
 
-from . import *
+from .constants import (PYSBOL3_MISSING, SBOL_CUT, SBOL_END,
+                        SBOL_ENTIRE_SEQUENCE, SBOL_ORDER, SBOL_ORIENTATION,
+                        SBOL_RANGE, SBOL_SEQUENCES, SBOL_START)
+from .document import Document
+from .identified import Identified
+from .int_property import IntProperty
+from .refobj_property import ReferencedObject
+from .sequence import Sequence
 from .typing import uri_singleton
+from .uri_property import URIProperty
+from .validation import ValidationReport
 
 int_property = Union[IntProperty, int]
 

--- a/sbol3/om_compound.py
+++ b/sbol3/om_compound.py
@@ -1,9 +1,15 @@
 import abc
-from typing import Union, List, Any
+from typing import Any, List, Union
 
-from . import *
-
+from .constants import (OM_HAS_BASE, OM_HAS_DENOMINATOR, OM_HAS_EXPONENT,
+                        OM_HAS_NUMERATOR, OM_HAS_TERM1, OM_HAS_TERM2, OM_LABEL,
+                        OM_SYMBOL, OM_UNIT_DIVISION, OM_UNIT_EXPONENTIATION,
+                        OM_UNIT_MULTIPLICATION, PYSBOL3_MISSING)
+from .document import Document
+from .int_property import IntProperty
+from .object import SBOLObject
 from .om_unit import Unit
+from .refobj_property import ReferencedObject
 
 
 class CompoundUnit(Unit, abc.ABC):


### PR DESCRIPTION
### Wild card imports were replaced with explicit relative imports for the following files:
1. document.py
2. location.py
3. om_compound.py

### Additional changes include (based on pylint's suggestion) :
1. Refactored if else block.
2. Replaced Dictionary method with Dictionary literal.