### PR TITLE
Update the python versions used to build and test

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # Default builds are on Ubuntu
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10', 'pypy-3.11']
         include:
           # Also test on macOS and Windows using latest Python 3
           - os: macos-latest


### PR DESCRIPTION
Drop Python 3.8, which is end of life. Add pypy-3.11 and Python 3.13. Drop end of life pypy versions.