### PR TITLE
Useless return statement

### DIFF
--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -763,7 +763,7 @@ class Document:
         if update_references is not None:
             for top_level in update_references:
                 top_level.update_all_dependents(identity_map)
-        return None
+        # return None # This is a void method
 
     def clone(self) -> List[TopLevel]:
         """Clone the top level objects in this document.

--- a/sbol3/document.py
+++ b/sbol3/document.py
@@ -763,7 +763,6 @@ class Document:
         if update_references is not None:
             for top_level in update_references:
                 top_level.update_all_dependents(identity_map)
-        # return None # This is a void method
 
     def clone(self) -> List[TopLevel]:
         """Clone the top level objects in this document.

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,5 +45,4 @@ disable = abstract-class-instantiated,
           unused-variable,
           unused-wildcard-import,
           useless-parent-delegation,
-          useless-return,
           wildcard-import


### PR DESCRIPTION
Pylint prefers no return statement over `return None` #433 